### PR TITLE
Update social-links.html to fix LinkedIn url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,7 +25,7 @@ twitter: mytwitter
 # google: mygoogle
 # instagram: myinstagram
 # pinterest: mypinterest
-linkedin: mylinkedin
+# linkedin: mylinkedin
 youtube: myyoutube
 spotify: myspotify
 github: mygithub

--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -30,7 +30,7 @@
     {% endif %}
 
     {% if site.linkedin %}
-        <a class="link" data-title="linkedin.com/{{ site.linkedin }}" href="http://linkedin.com/{{ site.linkedin }}" target="_blank">
+        <a class="link" data-title="linkedin.com/in{{ site.linkedin }}" href="http://linkedin.com/{{ site.linkedin }}" target="_blank">
             <svg class="icon icon-linkedin"><use xlink:href="#icon-linkedin"></use></svg>
         </a>
     {% endif %}

--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -30,7 +30,7 @@
     {% endif %}
 
     {% if site.linkedin %}
-        <a class="link" data-title="linkedin.com/in{{ site.linkedin }}" href="http://linkedin.com/{{ site.linkedin }}" target="_blank">
+        <a class="link" data-title="linkedin.com/in{{ site.linkedin }}" href="http://linkedin.com/in/{{ site.linkedin }}" target="_blank">
             <svg class="icon icon-linkedin"><use xlink:href="#icon-linkedin"></use></svg>
         </a>
     {% endif %}

--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -30,7 +30,7 @@
     {% endif %}
 
     {% if site.linkedin %}
-        <a class="link" data-title="linkedin.com/in{{ site.linkedin }}" href="http://linkedin.com/in/{{ site.linkedin }}" target="_blank">
+        <a class="link" data-title="linkedin.com/in/{{ site.linkedin }}" href="http://linkedin.com/in/{{ site.linkedin }}" target="_blank">
             <svg class="icon icon-linkedin"><use xlink:href="#icon-linkedin"></use></svg>
         </a>
     {% endif %}


### PR DESCRIPTION
The link to a user profile for LinkedIn has a 'in/' before the username.

Great work on this theme. 👍🏾
