### PR TITLE
Updating social links to fix Spotify and G+

### DIFF
--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -12,7 +12,7 @@
     {% endif %}
 
     {% if site.google %}
-        <a class="link" data-title="plus.google.com/{{ site.google }}" href="http://plus.google.com/{{ site.google }}" target="_blank">
+        <a class="link" data-title="plus.google.com/+{{ site.google }}" href="http://plus.google.com/+{{ site.google }}" target="_blank">
             <svg class="icon icon-google"><use xlink:href="#icon-google"></use></svg>
         </a>
     {% endif %}
@@ -42,7 +42,7 @@
     {% endif %}
 
     {% if site.spotify %}
-        <a class="link" data-title="spotify.com/{{ site.spotify }}" href="https://spotify.com/{{ site.spotify }}" target="_blank">
+        <a class="link" data-title="open.spotify.com/user/{{ site.spotify }}" href="https://open.spotify.com/user/{{ site.spotify }}" target="_blank">
             <svg class="icon icon-spotify"><use xlink:href="#icon-spotify"></use></svg>
         </a>
     {% endif %}


### PR DESCRIPTION
Hey Sergio, same as last time now for google+ (no man's land) and Spotify.
