### PR TITLE
[Fixed] htmlproof 2.6.4: 999 No error

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -3,4 +3,4 @@ set -e # halt script on error
 
 echo 'Testing travis...'
 bundle exec jekyll build
-bundle exec htmlproof ./_site
+bundle exec htmlproof ./_site --only-4xx


### PR DESCRIPTION
This fixes Travis-CI build failure for

 `htmlproof 2.6.4:  *  External link https://linkedin.com/in/ failed: 999 No error`
