### PR TITLE
Fix offset issue with first line of highlight

### DIFF
--- a/_includes/main.css
+++ b/_includes/main.css
@@ -369,7 +369,7 @@ figure.highlight {
 }
 code,
 tt {
-  padding: 1px 3px;
+  padding: 1px 0;
   font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
   font-size: 12px;
   line-height: 20px;

--- a/assets/styles/base/_general.styl
+++ b/assets/styles/base/_general.styl
@@ -95,7 +95,7 @@ figure.highlight
 
 code,
 tt
-	padding 1px 3px
+	padding 1px 0
 	font-family fontMonospace
 	font-size 12px
 	line-height 20px

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -369,7 +369,7 @@ figure.highlight {
 }
 code,
 tt {
-  padding: 1px 3px;
+  padding: 1px 0;
   font-family: Consolas, "Liberation Mono", Menlo, Courier, monospace;
   font-size: 12px;
   line-height: 20px;


### PR DESCRIPTION
If you look here:

https://koppl.in/indigo/markdown-common-elements/#lists

There's some padding that only seems to apply to the first line of the pre-formatted text. I've removed that horizontal padding and it's brought it all back into alignment.
