### PR TITLE
Added extensionless URLs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,7 +53,7 @@ GEM
     html-pipeline (2.3.0)
       activesupport (>= 2, < 5)
       nokogiri (>= 1.4)
-    html-proofer (2.6.4)
+    html-proofer (3.0.5)
       activesupport (~> 4.2)
       addressable (~> 2.3)
       colored (~> 1.2)
@@ -156,4 +156,4 @@ DEPENDENCIES
   rouge
 
 BUNDLED WITH
-   1.11.2
+   1.12.3

--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ picture: 'assets/images/profile.jpg'
 url: http://koppl.in/indigo
 # your url: http://USERNAME.github.io
 
-permalink: /:title/
+permalink: /:title
 
 markdown: kramdown
 highlighter: rouge

--- a/_config_dev.yml
+++ b/_config_dev.yml
@@ -1,2 +1,4 @@
 # for local testing
 url: http://localhost:3000
+# local testing does not yet support extensionless URLs
+permalink: /:title/

--- a/travis.sh
+++ b/travis.sh
@@ -3,4 +3,4 @@ set -e # halt script on error
 
 echo 'Testing travis...'
 bundle exec jekyll build
-bundle exec htmlproof ./_site --only-4xx
+bundle exec htmlproofer ./_site --only-4xx --assume-extension


### PR DESCRIPTION
This shifts the permalink style to use the [extensionless permalinks](https://jekyllrb.com/docs/permalinks/#extensionless-permalinks) enabled by both the jekyll server and gh-pages.

Whether or not to have a trailing slash at the end of the URL is definitely a style/preference point, but in my case I worked on it to maintain consistency based on existing links that I can't easily update. After digging around a little, I believe that the general preference is to avoid trailing slashes as well as the .html at the end of website URLs.

As discussed in #100, the current dev scripts don't allow for this feature so I added a workaround in `_config_dev.yml` to disable it there, still looking for an better fix to this.

In the meantime, this PR will allow for cleaner URL's in production and satisfactory Travis testing of the full production site.
