### PR TITLE
Fixes sergiokopplin/indigo#104 animation blink twice

### DIFF
--- a/_includes/main.css
+++ b/_includes/main.css
@@ -430,6 +430,8 @@ pre {
           animation: fade-in-down 0.6s;
   -webkit-animation-delay: 0.3s;
           animation-delay: 0.3s;
+  -webkit-animation-fill-mode: both;
+          animation-fill-mode: both;
 }
 @-webkit-keyframes fade-in-down {
   0% {

--- a/assets/styles/base/_helpers.styl
+++ b/assets/styles/base/_helpers.styl
@@ -21,6 +21,7 @@
  .animated
 	animation fade-in-down 0.6s
 	animation-delay .3s
+	animation-fill-mode both
 
 @keyframes fade-in-down
 	0%

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -430,6 +430,8 @@ pre {
           animation: fade-in-down 0.6s;
   -webkit-animation-delay: 0.3s;
           animation-delay: 0.3s;
+  -webkit-animation-fill-mode: both;
+          animation-fill-mode: both;
 }
 @-webkit-keyframes fade-in-down {
   0% {


### PR DESCRIPTION
I did a lot of work with animations on my site, so I knew what was missing to correct the issue. This changes the animation so it the visible block is set to its '0%' point of the animation as soon as it is drawn, rather than snapping to it later once the animation starts.
