### PR TITLE
Corrected blog pagination jekyll/jekyll#4903

### DIFF
--- a/_posts/2016-01-23-indigo-jekyll-theme.markdown
+++ b/_posts/2016-01-23-indigo-jekyll-theme.markdown
@@ -5,6 +5,7 @@ date: 2016-01-23 22:10
 tag: jekyll
 img: indigo/indigo.png
 projects: true
+hidden: true # don't count this post in blog pagination
 description: "This is a simple and minimalist template for Jekyll for those who likes to eat noodles."
 jemoji: '<img class="emoji" title=":ramen:" alt=":ramen:" src="https://assets.github.com/images/icons/emoji/unicode/1f35c.png" height="20" width="20" align="absmiddle">'
 ---


### PR DESCRIPTION
I found some issues with pagination of the blog posts (jekyll/jekyll#4903) and realized it was due to the Jekyll documentation not reflecting the ability to exclude posts from pagination.

In the case of this template, we want that for project posts since they are manually filtered out, otherwise pagination will think there are 4 blog posts + 3 projects, but only 4 blog posts will be shown and we will have a blank pagination page!

I got the Jekyll documentation updated, and fixing it here is an easy fix!
