### PR TITLE
Making padding of tags smaller so they don't overlap

### DIFF
--- a/_includes/main.css
+++ b/_includes/main.css
@@ -579,7 +579,7 @@ pre {
   margin-bottom: 2rem;
 }
 .post > .post-tags > .item {
-  padding: 3px 6px;
+  padding: 1px 9px;
   border-radius: 3px;
   font-size: 1.1rem;
   background: #ededed;

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -579,7 +579,7 @@ pre {
   margin-bottom: 2rem;
 }
 .post > .post-tags > .item {
-  padding: 3px 6px;
+  padding: 1px 9px;
   border-radius: 3px;
   font-size: 1.1rem;
   background: #ededed;

--- a/assets/styles/pages/_post.styl
+++ b/assets/styles/pages/_post.styl
@@ -22,7 +22,7 @@
         margin-bottom 2rem
 
     > .post-tags > .item
-        padding 3px 6px
+        padding 1px 9px
         border-radius 3px
         font-size 1.1rem
         background epsilon

--- a/assets/styles/pages/_tags.styl
+++ b/assets/styles/pages/_tags.styl
@@ -29,7 +29,7 @@
         margin-bottom 6rem
         -webkit-font-smoothing antialiased
         text-rendering optimizeLegibility
-        padding 3px 6px
+        padding 3px 9px
         border-radius 3px
         font-size 1.3rem
         background epsilon


### PR DESCRIPTION
Making padding of tags smaller so they don't overlap when going over several lines. Corrected issue #112.
