### PR TITLE
Fixed Twitter share link

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -8,7 +8,7 @@
         <p class="bio">{{ site.bio }}</p>
 
         <div class="share">
-            <a class="twitter" href="https://twitter.com/intent/tweet?text={{ site.url }}{{ page.url }} - {{ page.title }} by @{{ site.github }}">
+            <a class="twitter" href="https://twitter.com/intent/tweet?text={{ site.url }}{{ page.url }} - {{ page.title }} by @{{ site.twitter }}">
                 <svg class="icon icon-twitter"><use xlink:href="#icon-twitter"></use></svg><span class="icon-twitter">Tweet</span>
             </a>
 


### PR DESCRIPTION
Twitter share link used github username, not twitter username.
