### PR TITLE
Add tasks folder to Jekyll exclude list

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -78,4 +78,4 @@ gems:
 jekyll-mentions:
     base_url: https://github.com
 
-exclude: [README.md, Gemfile, Gemfile.lock, node_modules, gulpfile.js, package.json, _site, src, vendor, CNAME, indigo-gh-pages.zip, Rakefile, screen-shot.png, travis.sh]
+exclude: [README.md, Gemfile, Gemfile.lock, node_modules, gulpfile.js, package.json, _site, src, vendor, CNAME, indigo-gh-pages.zip, Rakefile, screen-shot.png, travis.sh, tasks]


### PR DESCRIPTION
A minor fix, I don't think the gulp tasks should end up in the compiled site.
