### PR TITLE
Email link shouldn't have a target (blank in this case)

### DIFF
--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -66,7 +66,7 @@
     {% endif %}
 
     {% if site.email %}
-        <a class="link" data-title="{{ site.email }}" href="mailto:{{ site.email }}" target="_blank">
+        <a class="link" data-title="{{ site.email }}" href="mailto:{{ site.email }}">
             <svg class="icon icon-mail"><use xlink:href="#icon-mail"></use></svg>
         </a>
     {% endif %}


### PR DESCRIPTION
Remove the target="_blank" from email link in social_links to avoid opening a blank page when clicking on it.
