### PR TITLE
Fixes broken stackoverflow link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,7 +38,7 @@ twitter: mytwitter
 youtube: myyoutube
 spotify: myspotify
 github: mygithub
-stackoverflow: mystackoverflow
+stackoverflow: 7044681/mystackoverflow
 medium: medium
 vimeo: myvimeo
 email: myemail@gmail.com


### PR DESCRIPTION
Fixes https://github.com/sergiokopplin/indigo/issues/176
Created a default stackoverflow user, namely http://stackoverflow.com/users/7044681/mystackoverflow
Every stackoverflow user has a numeric id, hence the numbers
