### PR TITLE
Adding resume support to the nav bar, configurable via _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,6 +10,12 @@ description: A blog about technology and stuff related
 external-image: false
 picture: assets/images/profile.jpg
 
+# If you want to include your resume, set to true
+# and specify source (external or local).
+resume: true
+resume-external: true
+resume-url: https://github.com/sergiokopplin/resume
+
 url: https://koppl.in/indigo
 # your url: http://USERNAME.github.io
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -29,5 +29,11 @@
                 </li>
             {% endif %}
         {% endif %}
+
+        {% if site.resume == true %}
+            <li class="item">
+                <a class="link" href="{% if site.resume-external %}{{ site.resume-url }}{% else %}{{ site.url }}/{{ site.resume-url }}{% endif %}">Resume</a>
+            </li>
+        {% endif %}
     </ul>
 </nav>


### PR DESCRIPTION
The following Pull Requests adds resume integration into this site's nav bar.

The `_config.yml` file has been updated to include the below variables:

```yml
resume: true
resume-external: true
resume-url: https://github.com/sergiokopplin/resume
```

Required:

- `resume`

Optional (required if `resume` is set to `true`):

- `resume-external`
- `resume-url`

Looking forward to feedback on this small feature - thanks!