### PR TITLE
Added identifier and url to disqus config

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -2,6 +2,10 @@
     <div id="disqus_thread"></div>
     <script type="text/javascript">
 
+        var disqus_config = function () {
+            this.page.url = '{{ site.url }}{{ page.url | replace:"index.html","" }}';
+            this.page.identifier = '{{ page.id }}';
+        };
         var disqus_shortname = '{{ site.disqus }}';
         var disqus_developer = 0;
         (function() {


### PR DESCRIPTION
Disqus recommends adding a [page identifier](https://help.disqus.com/customer/portal/articles/472098-javascript-configuration-variables#thispageidentifier) so if you change the title or url of a site the comments follow the change.

I'm currently using the Jekyll variable [page.id](https://jekyllrb.com/docs/variables/) which actually will change if someone renames it anyways, but at least this is the first few steps needed if someone wants to go ahead and add another variable to each disqus enabled post to give it a constant, unique ID.