### PR TITLE
Allow config of disqus and advance links with post categories

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -31,8 +31,10 @@ highlighter: rouge
 # analytics-piwik-url: 'piwik.my-host.com'
 # analytics-piwik-id: 1
 
-# if you don't want comments in your posts, set to false
-disqus: mydisqus
+# if you don't want comments in your posts, leave categories empty
+disqus:
+  shortname: mydisqus # enter this from your disqus account
+  categories: [blog, project] # only show disqus for posts that have these categories
 
 # if you don't have any of social below, comment the line
 facebook: myfacebook
@@ -90,8 +92,8 @@ show-tags: true
 # related posts inside a post?
 related: true
 
-# show next & prev links in blog post?
-blog-nav-links: false
+# Display links for next and previous posts for the specified categories
+post-advance-links: [blog]
 
 # show author block at the end of a post ?
 show-author: true

--- a/_includes/blog-post.html
+++ b/_includes/blog-post.html
@@ -1,8 +1,6 @@
-{% if post.blog == true %}
-    <div class="item {% if post.star %}star{% endif %}">
-        <a class="url" href="{{ site.url }}{{ post.url }}">
-            <aside class="date"><time datetime="{{ post.date | date:"%d-%m-%Y" }}">{{ post.date | date: "%b %d %Y" }}</time></aside>
-            {{ post.jemoji }}<h3 class="title">{{ post.title }}</h3>
-        </a>
-    </div>
-{% endif %}
+<div class="item {% if post.star %}star{% endif %}">
+    <a class="url" href="{{ site.url }}{{ post.url }}">
+        <aside class="date"><time datetime="{{ post.date | date:"%d-%m-%Y" }}">{{ post.date | date: "%b %d %Y" }}</time></aside>
+        {{ post.jemoji }}<h3 class="title">{{ post.title }}</h3>
+    </a>
+</div>

--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -2,7 +2,7 @@
     <div id="disqus_thread"></div>
     <script type="text/javascript">
 
-        var disqus_shortname = '{{ site.disqus }}';
+        var disqus_shortname = '{{ site.disqus.shortname }}';
         var disqus_developer = 0;
         (function() {
             var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -23,7 +23,7 @@ layout: page
 
 {{content}}
 
-{% if page.blog and site.blog-nav-links %}
+{% if site.post-advance-links contains page.category %}
     <div class="blog-navigation">
         {% if page.previous.url %}
             <a class="prev" href="{{ site.url }}{{ page.previous.url }}">&laquo; {{ page.previous.title }}</a>
@@ -44,6 +44,6 @@ layout: page
     {% include author.html %}
 {% endif %}
 
-{% if site.disqus %}
+{% if site.disqus.categories contains page.category %}
     {% include disqus.html %}
 {% endif %}

--- a/_posts/2015-02-24-markdown-extra-components.markdown
+++ b/_posts/2015-02-24-markdown-extra-components.markdown
@@ -8,7 +8,7 @@ tag:
 - markdown
 - components
 - extra
-blog: true
+category: blog
 author: jamesfoster
 description: Markdown summary with different options
 # jemoji: '<img class="emoji" title=":ramen:" alt=":ramen:" src="https://assets.github.com/images/icons/emoji/unicode/1f35c.png" height="20" width="20" align="absmiddle">'

--- a/_posts/2016-01-23-indigo-jekyll-theme.markdown
+++ b/_posts/2016-01-23-indigo-jekyll-theme.markdown
@@ -9,6 +9,7 @@ projects: true
 hidden: true # don't count this post in blog pagination
 description: "This is a simple and minimalist template for Jekyll for those who likes to eat noodles."
 jemoji: '<img class="emoji" title=":ramen:" alt=":ramen:" src="https://assets.github.com/images/icons/emoji/unicode/1f35c.png" height="20" width="20" align="absmiddle">'
+category: project
 author: johndoe
 externalLink: false
 ---

--- a/_posts/2016-02-24-markdown-common-elements.markdown
+++ b/_posts/2016-02-24-markdown-common-elements.markdown
@@ -7,8 +7,8 @@ headerImage: false
 tag:
 - markdown
 - elements
-blog: true
 star: true
+category: blog
 author: johndoe
 description: Markdown summary with different options
 ---

--- a/blog/index.html
+++ b/blog/index.html
@@ -9,12 +9,12 @@ title: Blog
 		<p class="text-center">Nothing published yet!</p>
 	{% elsif site.paginate %}
 		{% for post in paginator.posts %}
-	        {% include blog-post.html %}
-	    {% endfor %}
+			{% if post.category == 'blog' %}
+				{% include blog-post.html %}
+			{% endif %}
+		{% endfor %}
 
-		{% if site.paginate %}
-			{% include pagination.html%}
-		{% endif %}
+		{% include pagination.html%}
 	{% else %}
 		{% for post in site.posts %}
 			{% include blog-post.html %}


### PR DESCRIPTION
Instead of using `blog: true` to control whether a post is a blog or project page, I like the idea of giving it a named category using `category: blog` or `category: project`. This makes a bit a easier to understand, and actually opens up more configuration opens.

With this PR  you can easily add/remove disqus from blog and/or project posts as desired, and same goes for the nav advance links at the bottom of posts. It adds some extra configurability right from config.yml without adding a bunch of extra code!