### PR TITLE
Fix site links with local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
 2. Fork the project [Indigo](https://github.com/sergiokopplin/indigo/fork)
 3. Edit `_config.yml` with your data.
 4. `bundle install`
-5. `bundle exec jekyll serve`
+5. `bundle exec jekyll serve --config _config.yml,_config-dev.yml`
 6. open in your browser: `http://localhost:4000`
 
 ## Settings

--- a/_config-dev.yml
+++ b/_config-dev.yml
@@ -1,0 +1,3 @@
+# For local testing, run:
+# bundle exec jekyll serve --config _config.yml,_config-dev.yml
+url: http://localhost:4000


### PR DESCRIPTION
With the listed setup instructions, it is a pain to test locally since all hyperlinks point to the hosted site and take you away from localhost.

By overriding the `url` variable by using a [second dev only config](https://jekyllrb.com/docs/configuration/#build-command-options) we can easily work with a localhost version while not impacting the production build version.