### PR TITLE
+ Add support for creating a Publications page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ resume-url: https://google.com/?q=my+resume
 # If you want to include your publications via bibbase.org,
 # set to true and specify source of your citation history
 # in bibtex format
-publications: true
+publications: false
 citations_bib: 'assets/static/citations.bib'
 
 url: https://koppl.in/indigo

--- a/_config.yml
+++ b/_config.yml
@@ -16,6 +16,12 @@ resume: true
 resume-external: true
 resume-url: https://google.com/?q=my+resume
 
+# If you want to include your publications via bibbase.org,
+# set to true and specify source of your citation history
+# in bibtex format
+publications: true
+citations_bib: 'assets/static/citations.bib'
+
 url: https://koppl.in/indigo
 # your url: http://USERNAME.github.io
 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -35,5 +35,13 @@
                 <a class="link" href="{% if site.resume-external %}{{ site.resume-url }}{% else %}{{ site.url }}/{{ site.resume-url }}{% endif %}">Résumé</a>
             </li>
         {% endif %}
+
+        {% if site.publications == true %}
+            {% if page.title != "Publications" %}
+                <li class="item">
+                    <a class="link" href="{{ site.url }}/publications">Publications</a>
+                </li>
+            {% endif %}
+        {% endif %}
     </ul>
 </nav>

--- a/assets/static/citations.bib
+++ b/assets/static/citations.bib
@@ -1,0 +1,16476 @@
+
+%%% ====================================================================
+%%% Acknowledgement abbreviations:
+@String{ack-nhfb = "Nelson H. F. Beebe,
+                    University of Utah,
+                    Department of Mathematics, 110 LCB,
+                    155 S 1400 E RM 233,
+                    Salt Lake City, UT 84112-0090, USA,
+                    Tel: +1 801 581 5254,
+                    FAX: +1 801 581 4148,
+                    e-mail: \path|beebe@math.utah.edu|,
+                            \path|beebe@acm.org|,
+                            \path|beebe@computer.org| (Internet),
+                    URL: \path|http://www.math.utah.edu/~beebe/|"}
+
+%%% ====================================================================
+%%% Institutional abbreviations:
+@String{inst-INST-ADV-STUDY     = "Institute for Advanced Study"}
+@String{inst-INST-ADV-STUDY:adr = "Princeton, NJ, USA"}
+
+%%% ====================================================================
+%%% Journal abbreviations:
+@String{j-ADV-HIST-STUD         = "Advances in Historical Studies"}
+
+@String{j-ADV-SCI               = "Advancement of Science"}
+
+@String{j-AIP-CONF-PROC         = "AIP Conference Proceedings"}
+
+@String{j-AIR-FORCE-MAG         = "{Air Force} magazine"}
+
+@String{j-AM-BIOL-TEACH         = "The American Biology Teacher"}
+
+@String{j-AM-HIST-REV           = "The American Historical Review"}
+
+@String{j-AM-PROSPECT           = "The American Prospect"}
+
+@String{j-AM-SCH                = "American Scholar"}
+
+@String{j-AM-SCI                = "American Scientist"}
+
+@String{j-AMER-J-PHYSICS        = "American Journal of Physics"}
+
+@String{j-AMER-MATH-MONTHLY     = "American Mathematical Monthly"}
+
+@String{j-AMER-STAT             = "The American Statistician"}
+
+@String{j-ANGEW-CHEM            = "Angewandte Chemie"}
+
+@String{j-ANN-HIST-COMPUT       = "Annals of the History of Computing"}
+
+@String{j-ANN-MATH-2            = "Annals of Mathematics (2)"}
+
+@String{j-ANN-NUCL-ENERGY       = "Annals of Nuclear Energy"}
+
+@String{j-ANN-PHYS-1900         = "Annalen der Physik (1900)"}
+
+@String{j-ANN-PHYS-1900-4       = "Annalen der Physik (1900) (series 4)"}
+
+@String{j-ANN-PHYS-8            = "Annalen der Physik 8 (Berlin, Germany)"}
+
+@String{j-ANN-PHYS-BERLIN       = "{Annalen der Physik (Berlin)}"}
+
+@String{j-ANN-PHYS              = "Annals of Physics"}
+
+@String{j-ANN-SCIENCE           = "Annals of Science"}
+
+@String{j-ANNU-REV-ASTRON-ASTROPHYS = "Annual Review of Astronomy and Astrophysics"}
+
+@String{j-ANNU-REV-NUCL-PART-SCI = "Annual Review of Nuclear and Particle
+                                  Science"}
+
+@String{j-APPL-OPTICS           = "Applied Optics"}
+
+@String{j-ARCH-HIST-EXACT-SCI   = "Archive for History of Exact Sciences"}
+
+@String{j-ASTRO-NACHR           = "Astronomische Nachrichten"}
+
+@String{j-ASTRON-ASTROPHYS-REV  = "Astronomy and Astrophysics Review"}
+
+@String{j-ASTROPHYS-LETT        = "Astrophysical Letters"}
+
+@String{j-ASTROPHYSICAL-J       = "Astrophysical Journal"}
+
+@String{j-ATLANTIC-MONTHLY      = "Atlantic Monthly"}
+
+@String{j-BEIBL-ANN-PHYS        = "{Beibl{\"a}tter zu den Annalen der Physik}"}
+
+@String{j-BELL-LABS-TECH-J      = "Bell Labs Technical Journal"}
+
+@String{j-BELL-SYST-TECH-J      = "The Bell System Technical Journal"}
+
+@String{j-BER-WISSENSCHAFTGESCH = "{Berichte zur Wissenschaftsgeschichte}"}
+
+@String{j-BIOGR-MEM-NAT-ACAD-SCI = "Biographical memoirs --- National Academy
+                                  of Sciences of the United States of America"}
+
+@String{j-BIOGRAPH-MEMOIRS-FELLOWS-ROY-SOC = "Biographical Memoirs of Fellows of
+                                  the Royal Society"}
+
+@String{j-BRITISH-J-HIST-SCI    = "British Journal for the History of Science"}
+
+@String{j-BRITISH-J-PHILOS-SCI  = "The British Journal for the Philosophy of
+                                  Science"}
+
+@String{j-BULL-AMS              = "Bulletin of the American Mathematical Society"}
+
+@String{j-BULL-AT-SCI           = "Bulletin of the Atomic Scientists"}
+
+@String{j-C-R-ACAD-SCI-PARIS    = "Comptes rendus de l'Acad{\'e}mie des
+                                sciences, Paris"}
+
+@String{j-CACM                  = "Communications of the ACM"}
+
+@String{j-CAN-J-MATH            = "Canadian Journal of Mathematics = Journal
+                                  canadien de math{\'e}matiques"}
+
+@String{j-CENTAURUS             = "Centaurus: An International Journal of the
+                                  History of Science and its Cultural Aspects"}
+
+@String{j-CESK-CAS-FYZ-SEK-A    = "Ceskoslovensky Casopis pro Fyziku Sekce {A}"}
+
+@String{j-CHANCE                = "Chance"}
+
+@String{j-CHEM-REV              = "Chemical Reviews"}
+
+@String{j-CHRON-HIGHER-ED       = "The Chronicle of Higher Education"}
+
+@String{j-CLASS-QUANTUM-GRAV    = "Classical and Quantum Gravity"}
+
+@String{j-COMP-GRAPHICS         = "Computer Graphics"}
+
+@String{j-COMPUT-SCI-ENG        = "Computing in Science and Engineering"}
+
+@String{j-COMPUTER              = "Computer"}
+
+@String{j-CONTEMP-PHYS          = "Contemporary Physics"}
+
+@String{j-CURR-SCI              = "Current Science"}
+
+@String{j-DAEDALUS              = "D{\ae}dalus"}
+
+@String{j-DIALECTICA            = "Dialectica: International Review of
+                                  Philosophy of Knowledge"}
+
+@String{j-DIPL-HIST             = "Diplomatic History"}
+
+@String{j-ECONOMIST             = "The Economist"}
+
+@String{j-EDU-CHEM              = "Education in Chemistry"}
+
+@String{j-ELECTRON-POWER        = "Electronics and Power"}
+
+@String{j-ELEM-MATH             = "{Elemente der Mathematik}"}
+
+@String{j-ENDEAVOUR             = "Endeavour"}
+
+@String{j-ENVIRON-HIST          = "Environmental History"}
+
+@String{j-EUR-J-PHYS            = "European Journal of Physics"}
+
+@String{j-EUR-PHYS-J-H          = "European Physical Journal H"}
+
+@String{j-EUR-REV-HIST          = "European Review of History = Revue
+                                  europ{\'e}enne d'histoire"}
+
+@String{j-EUROPHYS-NEWS         = "Europhysics News"}
+
+@String{j-EXP-NEUROL            = "Experimental Neurology"}
+
+@String{j-FIZ-SZ                = "Fizikai Szemle (Budapest)"}
+
+@String{j-FOREIGN-AFFAIRS       = "Foreign Affairs"}
+
+@String{j-FOUND-CHEM            = "Foundations of Chemistry"}
+
+@String{j-FOUND-PHYS            = "Foundations of Physics"}
+
+@String{j-GEN-RELATIVITY-GRAV   = "General Relativity and Gravitation"}
+
+@String{j-HARPERS-MAG           = "Harper's Magazine"}
+
+@String{j-HIST-MATH             = "Historia Mathematica"}
+
+@String{j-HIST-SCI              = "Historia Scientiarum = International journal
+                                  of the {History of Science Society of Japan}"}
+
+@String{j-HIST-SCI-UK           = "History of Science (UK)"}
+
+@String{j-HIST-STUD-NAT-SCI     = "Historical Studies in the Natural Sciences"}
+
+@String{j-HIST-STUD-PHYS-BIOL-SCI = "Historical Studies in the Physical and
+                                  Biological Sciences"}
+
+@String{j-HIST-STUD-PHYS-SCI    = "Historical Studies in the Physical Sciences"}
+
+@String{j-IAEA-BULL             = "{International Atomic Energy Agency}
+                                  Bulletin"}
+
+@String{j-IEEE-ASSP-MAG         = "IEEE ASSP Magazine"}
+
+@String{j-IEEE-SPECTRUM         = "IEEE Spectrum"}
+
+@String{j-IJQC                  = "International Journal of Quantum Chemistry"}
+
+@String{j-INT-AFF               = "International Affairs (Royal Institute of
+                                  International Affairs 1944--)"}
+
+@String{j-INT-J-MOD-PHYS-D      = "International journal of modern physics. D,
+                                  Gravitation, astrophysics, cosmology"}
+
+@String{j-INT-J-THEOR-PHYS      = "International Journal of Theoretical
+                                  Physics"}
+
+@String{j-ISIS                  = "Isis"}
+
+@String{j-J-AM-HIST             = "The Journal of American History"}
+
+@String{j-J-AM-SOC-INF-SCI      = "Journal of the American Society for
+                                  Information Science"}
+
+@String{j-J-AM-SOC-INF-SCI-TECHNOL = "Journal of the American Society for
+                                  Information Science and Technology: JASIST"}
+
+@String{j-J-APPL-PHYS           = "Journal of Applied Physics"}
+
+@String{j-J-ASSOC-INF-SCI-TECHNOL = "Journal of the Association for Information
+                                  Science and Technology"}
+
+@String{j-J-BR-ASTRON-ASSOC     = "Journal of the British Astronomical
+                                  Association"}
+
+@String{j-J-CHEM-EDUC           = "Journal of Chemical Education"}
+
+@String{j-J-COLD-WAR-STUD       = "Journal of Cold War Studies"}
+
+@String{j-J-COLLOID-INTERFACE-SCI = "Journal of Colloid and Interface Science"}
+
+@String{j-J-FRANKLIN-INST       = "Journal of {The Franklin Institute}"}
+
+@String{j-J-HIST-ASTRON         = "Journal for the History of Astronomy"}
+
+@String{j-J-INFORMETRICS =        "Journal of Informetrics"}
+
+@String{j-J-INTERDISCIP-HIST    = "Journal of Interdisciplinary History"}
+
+@String{j-J-MATH-PHYS           = "Journal of Mathematical Physics"}
+
+@String{j-J-MOD-HIST            = "The Journal of Modern History"}
+
+@String{j-J-PHILOS              = "The Journal of Philosophy"}
+
+@String{j-J-PHYS-CONDENS-MATTER = "Journal of Physics: Condensed Matter"}
+
+@String{j-J-PHYS-CONF-SER       = "Journal of Physics: Conference Series"}
+
+@String{j-J-PHYS-RADIUM         = "Journal de Physique et le Radium"}
+
+@String{j-J-SYMBOLIC-LOGIC      = "Journal of Symbolic Logic"}
+
+@String{j-JACS                  = "Journal of the American Chemical Society"}
+
+@String{j-JOURNAL-Q             = "Journalism Quarterly"}
+
+@String{j-JPN-STUD-HIST-SCI     = "Japanese Studies in the History of Science"}
+
+@String{j-LANCET                = "The Lancet (London, England)"}
+
+@String{j-LASER-FOCUS-WORLD     = "Laser Focus World"}
+
+@String{j-LEONARDO              = "Leonardo (Oxford, England)"}
+
+@String{j-LIBR-J                = "Library Journal"}
+
+@String{j-LIVING-REV-RELATIVITY = "Living Reviews in Relativity"}
+
+@String{j-MATH-ANN              = "Mathematische Annalen"}
+
+@String{j-MATH-GAZ              = "Mathematical Gazette"}
+
+@String{j-MATH-MAG              = "Mathematics Magazine"}
+
+@String{j-MATH-NATURWISS-UNTERR = "Mathematische und Naturwissenschaftliche
+                                  Unterricht"}
+
+@String{j-MATH-PROC-CAMB-PHILOS-SOC = "Mathematical proceedings of the Cambridge
+                                  Philosophical Society"}
+
+@String{j-MATHEMATICA-J         = "Mathematica Journal"}
+
+@String{j-MECH-ENG              = "Mechanical Engineering: the journal of the
+                                  American Society of Mechanical Engineers"}
+
+@String{j-MED-HYPOTH            = "Medical Hypotheses"}
+
+@String{j-MEDIA-HIST            = "Media History"}
+
+@String{j-MINERVA-WASHINGTON    = "Minerva [{Washington, DC}]"}
+
+@String{j-MOL-CELL-BIOCHEM      = "Molecular and Cellular Biochemistry"}
+
+@String{j-MONTHLY-NOT-ROY-ASTRON-SOC = "Monthly Notices of the Royal
+                                  Astronomical Society"}
+
+@String{j-NAMS                  = "Notices of the American Mathematical
+                                  Society"}
+
+@String{j-NAT-PHILOS            = "The Natural Philosopher"}
+
+@String{j-NATION                = "The Nation"}
+
+@String{j-NATURE                = "Nature"}
+
+@String{j-NATURE-COMMUN         = "Nature Communications"}
+
+@String{j-NATURE-DIGEST         = "Nature Digest"}
+
+@String{j-NATURE-MATER          = "Nature Materials"}
+
+@String{j-NATURE-MEDICINE       = "Nature Medicine"}
+
+@String{j-NATURE-NEWS           = "Nature News"}
+
+@String{j-NATURE-PHOTONICS      = "Nature Photonics"}
+
+@String{j-NATURE-PHYSICS        = "Nature Physics"}
+
+@String{j-NATURWISS-RUNDSCH     = "Naturwissenschaftliche Rundschau"}
+
+@String{j-NATURWISSENSCHAFTEN   = "Die Naturwissenschaften"}
+
+@String{j-NEUROSCI-LETT         = "Neuroscience Letters"}
+
+@String{j-NEW-REPUBLIC          = "New Republic"}
+
+@String{j-NEW-SCIENTIST         = "New Scientist"}
+
+@String{j-NEW-STATESMAN-SOC     = "New Statesman Society"}
+
+@String{j-NEW-YORK-REV-BOOKS    = "New York Review of Books"}
+
+@String{j-NEW-YORK-TIMES-BOOK-REVIEW = "New York Times Book Review"}
+
+@String{j-NEW-YORKER            = "The New Yorker"}
+
+@String{j-NEWSWEEK              = "Newsweek"}
+
+@String{j-NOTES-REC-R-SOC-LOND  = "Notes and Records of the Royal Society of
+                                  London"}
+
+@String{j-NTM                   = "{NTM Zeitschrift f{\"u}r Geschichte
+                                  der Wissenschaften, Technik und
+                                  Medizin}"}
+
+@String{j-NUNCIUS               = "Nuncius"}
+
+@String{j-NUOVO-CIMENTO-8       = "Il Nuovo Cimento (8)"}
+
+@String{j-NY-TIMES              = "New York Times"}
+
+@String{j-OAK-RIDGER            = "The {Oak Ridger}"}
+
+@String{j-OSIRIS-2              = "Osiris (Series 2)"}
+
+@String{j-PERSPECT-SCI          = "Perspectives on Science"}
+
+@String{j-PHILOS-SCI            = "Philosophy of Science"}
+
+@String{j-PHILOS-TRANS-R-SOC-LOND-SER-A = "Philosophical Transactions of the
+                                  Royal Society A: Mathematical, Physical, and
+                                  Engineering Sciences"}
+
+@String{j-PHYS-BL               = "{Physikalische Bl{\"a}tter}"}
+
+@String{j-PHYS-EDUC             = "Physics Education"}
+
+@String{j-PHYS-J                = "Physik Journal"}
+
+@String{j-PHYS-PERSPECT         = "Physics in Perspective (PIP)"}
+
+@String{j-PHYS-REV              = "Physical Review"}
+
+@String{j-PHYS-REV-2            = "Physical Review (2)"}
+
+@String{j-PHYS-REV-D            = "Physical Review D (Particles and Fields)"}
+
+@String{j-PHYS-REV-LET          = "Physical Review Letters"}
+
+@String{j-PHYS-TEACHER          = "The Physics Teacher"}
+
+@String{j-PHYS-TODAY            = "Physics Today"}
+
+@String{j-PHYS-UNSERER-ZEIT     = "{Physik in unserer Zeit}"}
+
+@String{j-PHYS-WORLD            = "Physics World"}
+
+@String{j-PHYS-Z-SOWJETUNION    = "Physikalische Zeitschrift der Sowjetunion"}
+
+@String{j-PHYSICA               = "Physica"}
+
+@String{j-PHYSICA-A             = "Physica A"}
+
+@String{j-PHYSIKAL-Z            = "Physikalische Zeitschrift"}
+
+@String{j-PHYSIS                = "Physis: Rivista Internazionale di Storia
+                                  della Scienza"}
+
+@String{j-PHYSIS-NS             = "Physis: Rivista Internazionale di Storia
+                                  della Scienza. Nuova Serie"}
+
+@String{j-POLITY                = "Polity"}
+
+@String{j-PROBL-PEREDA-INF      = "Problemy Peredachi Informatsii"}
+
+@String{j-PROC-AMER-PHIL-SOC    = "Proceedings of the {American Philosophical
+                                  Society} held at {Philadelphia} for promoting
+                                  useful knowledge"}
+
+@String{j-PROC-CAMBRIDGE-PHIL-SOC = "Proceedings of the Cambridge Philosophical
+                                  Society. Mathematical and physical sciences"}
+
+@String{j-PROC-NATL-ACAD-SCI-USA = "Proceedings of the National Academy of
+                                 Sciences of the United States of America"}
+
+@String{j-PROC-R-SOC-LOND-SER-A-MATH-PHYS = "Proceedings of the Royal Society
+                                  of London. Series A, Containing Papers of a
+                                  Mathematical and Physical Character"}
+
+@String{j-Q-J-R-ASTRON-SOC      = "Quarterly Journal of the Royal Astronomical
+                                  Society"}
+
+@String{j-QUAD-STORIA-FISICA    = "Quaderni di Storia della fisica"}
+
+@String{j-RADIOCHIM-ACTA        = "Radiochimica Acta"}
+
+@String{j-RECHERCHE             = "La Recherche"}
+
+@String{j-REP-PROG-PHYS         = "Reports on Progress in Physics"}
+
+@String{j-RESONANCE             = "Resonance"}
+
+@String{j-REV-AM-HIST           = "Reviews in American History"}
+
+@String{j-REV-HIST-SCI          = "Revue d'Histoire des Sciences"}
+
+@String{j-REV-HIST-SCI-LEURS-APPL = "Revue d'Histoire des Sciences et de
+                                  Leurs Applications"}
+
+@String{j-REV-MOD-PHYS          = "Reviews of Modern Physics"}
+
+@String{j-REV-QUEST-SCI         = "Revue des Questions Scientifiques"}
+
+@String{j-S-B-PREUSS-AKAD-WISS-1 = "St{\"a}ndiger Beobachter der Preussischen
+                                  Akademie der Wissenschaften, Part 1"}
+
+@String{j-S-B-PREUSS-AKAD-WISS-2 = "St{\"a}ndiger Beobachter der Preussischen
+                                  Akademie der Wissenschaften, Part 2"}
+
+@String{j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL = "St{\"a}ndiger Beobachter der
+                                  Preussischen Akademie der Wissenschaften,
+                                  Phys.-math. Klasse, Sitzungsberichte"}
+
+@String{j-SCI-AMER              = "Scientific American"}
+
+@String{j-SCI-COMPUT            = "Scientific Computing"}
+
+@String{j-SCI-CONTEXT           = "Science in Context"}
+
+@String{j-SCI-EDUC-SPRINGER     = "Science \& Education (Springer)"}
+
+@String{j-SCI-MONTHLY           = "The Scientific Monthly"}
+
+@String{j-SCI-NEWS-LETT         = "The Science News-Letter"}
+
+@String{j-SCI-PUBLIC-POL        = "Science and Public Policy"}
+
+@String{j-SCI-TECHNOL-HUMAN-VALUES = "Science, Technology and Human Values"}
+
+@String{j-SCIENCE               = "Science"}
+
+@String{j-SCIENCE-NEW-SERIES    = "Science (New Series)"}
+
+@String{j-SCIENCE-NEWS          = "Science News (Washington, DC)"}
+
+@String{j-SCIENTIA-MILAN        = "Scientia (Milan)"}
+
+@String{j-SCIENTIST             = "The Scientist (Philadelphia, PA)"}
+
+@String{j-SCIENTOMETRICS        = "Scientometrics"}
+
+@String{j-SIAM-REVIEW           = "SIAM Review"}
+
+@String{j-SMITHSONIAN           = "Smithsonian"}
+
+@String{j-SOC-PROBL             = "Social Problems"}
+
+@String{j-SOC-STUD-SCI          = "Social Studies of Science"}
+
+@String{j-SOC-TEXT              = "Social Text"}
+
+@String{j-SPEKTRUM-WISSENSCHAFT = "Spektrum der Wissenschaft (German translation
+                                  of Scientific American)"}
+
+@String{j-STUD-HIST-PHILOS-SCI  = "Studies in History and Philosophy of Science
+                                  {Part A}"}
+
+@String{j-STUD-HIST-PHILOS-SCI-B = "Studies in History and Philosophy of Science
+                                  Part B: Studies In History and
+                                  Philosophy of Modern Physics"}
+
+@String{j-STUD-HIST-PHILOS-MOD-PHYS = "Studies in History and Philosophy of
+                                  Modern Physics"}
+
+@String{j-STUD-STOR             = "Studi Storici"}
+
+@String{j-STUDIA-ROSE           = "Studia Rosenthaliana"}
+
+@String{j-TECH-CULTURE          = "Technology and Culture"}
+
+@String{j-TECH-REVIEW           = "Technology Review (M.I.T.)"}
+
+@String{j-THEOR-COMP-SCI        = "Theoretical Computer Science"}
+
+@String{j-TIME                  = "Time"}
+
+@String{j-TRANS-AM-PHILOS-SOC-N-S = "Transactions of the American Philosophical
+                                  Society, New Series"}
+
+@String{j-ULTIM-REAL-MEAN       = "Ultimate Reality and Meaning"}
+
+@String{j-UNIVERSITAS           = "{Universitas: Zeitschrift f{\"u}r
+                                  interdisziplin{\"a}re Wissenschaft}"}
+
+@String{j-US-NEWS-WORLD-REP     = "US News and World Report"}
+
+@String{j-USPEKHI-FIZ-NAUK      = "Uspekhi Fizicheskikh Nauk"}
+
+@String{j-VERH-DTSCH-PHYS-GES   = "{Verhandlungen der Deutschen
+                                  Physikalischen Gesellschaft}"}
+
+@String{j-VIC-STUD              = "Victorian Studies"}
+
+@String{j-VJSCHR-NATURF-GES-ZURICH = "{Vierteljahrsschrift Naturforschende
+                                  Gesellschaft, Z{\"u}rich}"}
+
+%%% \cite{Calaprice:2004:EA} uses this journal name:
+@String{j-VJSCHR-NATURF-GES-ZURICH = "{Naturforschende Gesellschaft in
+                                  Z{\"u}rich, Vierteljahrsschrift}"}
+
+@String{j-Z-ALLG-WISSENSCHAFTSTHEOR = "Zeitschrift f{\"u}r allgemeine
+                                  Wissenschaftstheorie / Journal for
+                                  General Philosophy of Science"}
+
+@String{j-Z-ANGE-CHEM           = "{Zeitschrift f{\"u}r Angewandte Chemie}"}
+
+@String{j-Z-ANGE-MATH-MECH      = "{Zeitschrift f{\"u}r Angewandte Mathematik
+                                  und Mechanik}"}
+
+@String{j-Z-PHYSIK              = "{Zeitschrift f{\"u}r Physik}"}
+
+%%% ====================================================================
+%%% Publishers and their addresses:
+@String{pub-A-K-PETERS          = "A. K. Peters, Ltd."}
+@String{pub-A-K-PETERS:adr      = "Wellesley, MA, USA"}
+
+@String{pub-ACADEMIC            = "Academic Press"}
+@String{pub-ACADEMIC:adr        = "New York, NY, USA"}
+
+@String{pub-ACAD-ROY-BELG       = "L'Acad{\'e}mie Royale de Belgique"}
+@String{pub-ACAD-ROY-BELG:adr   = "Bruxelles, Belgique"}
+
+@String{pub-ADAM-HILGER         = "Adam Hilger Ltd."}
+@String{pub-ADAM-HILGER:adr     = "Bristol, UK"}
+
+@String{pub-AIP                 = "American Institute of Physics"}
+@String{pub-AIP:adr             = "Woodbury, NY, USA"}
+
+@String{pub-ALPHA               = "Alpha Books"}
+@String{pub-ALPHA:adr           = "Indianapolis, IN, USA"}
+
+@String{pub-AKADEMIE-VERLAG     = "Akademie-Verlag"}
+@String{pub-AKADEMIE-VERLAG:adr = "Berlin, Germany"}
+
+@String{pub-AMS                 = "American Mathematical Society"}
+@String{pub-AMS:adr             = "Providence, RI, USA"}
+
+@String{pub-ANCHOR-BOOKS        = "Anchor Books"}
+@String{pub-ANCHOR-BOOKS:adr    = "New York, NY, USA"}
+
+@String{pub-ASHGATE             = "Ashgate"}
+@String{pub-ASHGATE:adr         = "Aldershot, Hampshire, England"}
+
+@String{pub-AW                  = "Ad{\-d}i{\-s}on-Wes{\-l}ey"}
+@String{pub-AW:adr              = "Reading, MA, USA"}
+
+@String{pub-AW-LONGMAN          = "Ad{\-d}i{\-s}on-Wes{\-l}ey Longman"}
+@String{pub-AW-LONGMAN:adr      = "Reading, MA, USA"}
+
+@String{pub-BALLANTINE          = "Ballantine Books"}
+@String{pub-BALLANTINE:adr      = "New York, NY, USA"}
+
+@String{pub-BANTAM              = "Bantam Books"}
+@String{pub-BANTAM:adr          = "New York, NY, USA"}
+
+@String{pub-BASIC-BOOKS         = "Basic Books"}
+@String{pub-BASIC-BOOKS:adr     = "New York, NY, USA"}
+
+@String{pub-BEACON              = "Beacon Press"}
+@String{pub-BEACON:adr          = "Boston, MA, USA"}
+
+@String{pub-BELKNAP             = "Belknap Press of Harvard University Press"}
+@String{pub-BELKNAP:adr         = "Cambridge, MA, USA; London, UK"}
+
+@String{pub-BENCUM              = "Benjamin/Cummings Pub. Co."}
+@String{pub-BENCUM:adr          = "Redwood City, CA, USA"}
+
+@String{pub-BERKLEY-BOOKS       = "Berkley Books"}
+@String{pub-BERKLEY-BOOKS:adr   = "New York, NY, USA"}
+
+@String{pub-BIRKHAUSER          = "Birkh{\"a}user"}
+@String{pub-BIRKHAUSER:adr      = "Cambridge, MA, USA; Berlin, Germany; Basel,
+                                  Switzerland"}
+
+@String{pub-BIRKHAUSER-BOSTON   = "Birkh{\"a}user Boston Inc."}
+@String{pub-BIRKHAUSER-BOSTON:adr = "Cambridge, MA, USA"}
+
+@String{pub-BLACKIE             = "Blackie"}
+@String{pub-BLACKIE:adr         = "Glasgow, Scotland"}
+
+@String{pub-BRILL               = "Brill"}
+@String{pub-BRILL:adr           = "Leiden, The Netherlands"}
+
+@String{pub-BSB-TEUBNER         = "BSB Teubner"}
+@String{pub-BSB-TEUBNER:adr     = "Leipzig, Germany"}
+
+@String{pub-BUTTERWORTHS        = "Butterworths"}
+@String{pub-BUTTERWORTHS:adr    = "London, UK"}
+
+@String{pub-CAMBRIDGE           = "Cambridge University Press"}
+@String{pub-CAMBRIDGE:adr       = "Cambridge, UK"}
+
+@String{pub-CHAPMAN-HALL        = "Chapman and Hall, Ltd."}
+@String{pub-CHAPMAN-HALL:adr    = "London, UK"}
+
+@String{pub-CITADEL-PRESS       = "Citadel Press"}
+@String{pub-CITADEL-PRESS:adr   = "New York, NY, USA"}
+
+@String{pub-CLARENDON           = "Clarendon Press"}
+@String{pub-CLARENDON:adr       = "New York, NY, USA"}
+
+@String{pub-CLARENDON           = "Clarendon Press"}
+@String{pub-CLARENDON:adr       = "Oxford, UK"}
+
+@String{pub-COLLINS             = "Collins"}
+@String{pub-COLLINS:adr         = "London, UK"}
+
+@String{pub-COLUMBIA            = "Columbia University Press"}
+@String{pub-COLUMBIA:adr        = "New York, NY, USA"}
+
+@String{pub-CORNELL             = "Cornell University Press"}
+@String{pub-CORNELL:adr         = "Ithaca, NY, USA"}
+
+@String{pub-CRC                 = "CRC Press"}
+@String{pub-CRC:adr             = "2000 N.W. Corporate Blvd., Boca Raton,
+                                  FL 33431-9868, USA"}
+
+@String{pub-CROWN               = "Crown Publishers"}
+@String{pub-CROWN:adr           = "New York, NY, USA"}
+
+@String{pub-CROWN-TRADE-PAPERBACKS = "Crown Trade Paperbacks"}
+@String{pub-CROWN-TRADE-PAPERBACKS:adr = "New York, NY, USA"}
+
+@String{pub-DA-CAPO             = "Da Capo Press"}
+@String{pub-DA-CAPO:adr         = "New York, NY, USA and Cambridge, MA, USA"}
+
+@String{pub-DEKKER              = "Marcel Dekker, Inc."}
+@String{pub-DEKKER:adr          = "New York, NY, USA"}
+
+@String{pub-DOUBLEDAY           = "Doubleday"}
+@String{pub-DOUBLEDAY:adr       = "Garden City, NY, USA"}
+
+@String{pub-DOVER               = "Dover"}
+@String{pub-DOVER:adr           = "New York, NY, USA"}
+
+@String{pub-DUNOD               = "Dunod"}
+@String{pub-DUNOD:adr           = "Paris, France"}
+
+@String{pub-ELSEVIER            = "Elsevier"}
+@String{pub-ELSEVIER:adr        = "Amsterdam, The Netherlands"}
+
+@String{pub-EUROPA              = "Europa Verlag"}
+@String{pub-EUROPA:adr          = "M{\"u}nchen, Germany and Z{\"u}rich, Switzerland"}
+
+@String{pub-FARRAR              = "Farrar, Strauss, and Giroux"}
+@String{pub-FARRAR:adr          = "New York, NY, USA"}
+
+@String{pub-FONTANA             = "Fontana Press"}
+@String{pub-FONTANA:adr         = "London, UK"}
+
+@String{pub-FREE-PRESS          = "Free Press"}
+@String{pub-FREE-PRESS:adr      = "New York, NY, USA"}
+
+@String{pub-FRONTIERES          = "Editions Fronti{\`e}res"}
+@String{pub-FRONTIERES:adr      = "Gif-sur-Yvette, France"}
+
+@String{pub-GAUTHIER            = "Gauthier"}
+@String{pub-GAUTHIER:adr        = "Paris, France"}
+
+@String{pub-GAUTHIER-VILLARS    = "Gauthier-Villars"}
+@String{pub-GAUTHIER-VILLARS:adr = "Paris, France"}
+
+@String{pub-GOLLANCZ            = "Gollancz"}
+@String{pub-GOLLANCZ:adr        = "London, UK"}
+
+@String{pub-GREENWOOD           = "Greenwood Press"}
+@String{pub-GREENWOOD:adr       = "88 Post Road West, Westport, CT 06881, USA"}
+
+@String{pub-GROVE               = "Grove Press"}
+@String{pub-GROVE:adr           = "New York, NY, USA"}
+
+@String{pub-GRUYTER             = "Walter de Gruyter"}
+@String{pub-GRUYTER:adr         = "Berlin, Germany"}
+
+@String{pub-HARPER-ROW          = "Harper \& Row"}
+@String{pub-HARPER-ROW:adr      = "New York, NY, USA"}
+
+@String{pub-HARPERCOLLINS       = "HarperCollins College Publishers"}
+@String{pub-HARPERCOLLINS:adr   = "New York, NY, USA"}
+
+@String{pub-HARVARD             = "Harvard University Press"}
+@String{pub-HARVARD:adr         = "Cambridge, MA, USA"}
+
+@String{pub-HENRY-HOLT          = "Henry Holt and Company, Incorporated"}
+@String{pub-HENRY-HOLT:adr      = "New York, NY, USA"}
+
+@String{pub-HERMANN             = "Hermann"}
+@String{pub-HERMANN:adr         = "Paris, France"}
+
+@String{pub-HODDER-STOUGHTON    = "Hodder and Stoughton"}
+@String{pub-HODDER-STOUGHTON:adr = "London, UK"}
+
+@String{pub-HOUGHTON-MIFFLIN    = "Houghton-Mifflin"}
+@String{pub-HOUGHTON-MIFFLIN:adr = "Boston, MA, USA"}
+
+@String{pub-HRW                 = "Holt, Rinehart, and Winston"}
+@String{pub-HRW:adr             = "New York, NY, USA"}
+
+@String{pub-INDIANA             = "Indiana University Press"}
+@String{pub-INDIANA:adr         = "Bloomington, IN, USA"}
+
+@String{pub-INTERSCIENCE        = "Interscience Publishers"}
+@String{pub-INTERSCIENCE:adr    = "New York, NY, USA"}
+
+@String{pub-IOP                 = "Institute of Physics Publishers"}
+@String{pub-IOP:adr             = "Bristol, UK"}
+
+@String{pub-IOS                 = "IOS Press"}
+@String{pub-IOS:adr             = "Amsterdam, The Netherlands"}
+
+@String{pub-JOHNATHAN-CAPE      = "Jonathan Cape"}
+@String{pub-JOHNATHAN-CAPE:adr  = "London, UK"}
+
+@String{pub-JOHNS-HOPKINS       = "The Johns Hopkins University Press"}
+@String{pub-JOHNS-HOPKINS:adr   = "Baltimore, MD, USA"}
+
+@String{pub-JONES-BARTLETT      = "Jones and Bartlett"}
+@String{pub-JONES-BARTLETT:adr  = "Boston, MA, USA"}
+
+@String{pub-JOSEPH-HENRY        = "Joseph Henry Press"}
+@String{pub-JOSEPH-HENRY:adr    = "Washington, DC, USA"}
+
+@String{pub-JULIUS-SPRINGER     = "Julius Springer"}
+@String{pub-JULIUS-SPRINGER:adr = "Berlin, Germany"}
+
+@String{pub-KLUWER              = "Kluwer Academic Publishers Group"}
+@String{pub-KLUWER:adr          = "Norwell, MA, USA, and Dordrecht,
+                                  The Netherlands"}
+
+@String{pub-KNOPF               = "Alfred A. Knopf"}
+@String{pub-KNOPF:adr           = "New York, NY, USA"}
+
+@String{pub-LEXINGTON           = "Lexington Books"}
+@String{pub-LEXINGTON:adr       = "Lexington, MA, USA"}
+
+@String{pub-LITTLE-BROWN        = "Little, Brown and Co."}
+@String{pub-LITTLE-BROWN:adr    = "Boston, MA, USA"}
+
+@String{pub-LOS-ALAMOS-HISTORICAL-SOCIETY = "Los Alamos Historical Society"}
+@String{pub-LOS-ALAMOS-HISTORICAL-SOCIETY:adr = "Los Alamos, NM, USA"}
+
+@String{pub-MACMILLAN           = "Macmillan Publishing Company"}
+@String{pub-MACMILLAN:adr       = "New York, NY, USA"}
+
+@String{pub-MANCHESTER-UNIV-PRESS = "Manchester University Press"}
+@String{pub-MANCHESTER-UNIV-PRESS:adr = "Manchester, UK"}
+
+@String{pub-MCGRAW-HILL         = "Mc{\-}Graw-Hill"}
+@String{pub-MCGRAW-HILL:adr     = "New York, NY, USA"}
+
+@String{pub-MECKLER             = "Meckler Corp."}
+@String{pub-MECKLER:adr         = "11 Ferry Lane West, Westport, CT 06880, USA"}
+
+@String{pub-METHUEN             = "Methuen and Co. Ltd."}
+@String{pub-METHUEN:adr         = "London, UK"}
+
+@String{pub-MIT                 = "MIT Press"}
+@String{pub-MIT:adr             = "Cambridge, MA, USA"}
+
+@String{pub-NAUKA               = "Nauka"}
+@String{pub-NAUKA:adr           = "Moscow, USSR"}
+
+@String{pub-NORTH-HOLLAND       = "North-Hol{\-}land"}
+@String{pub-NORTH-HOLLAND:adr   = "Amsterdam, The Netherlands"}
+
+@String{pub-NORTON              = "W. W. Norton \& Co."}
+@String{pub-NORTON:adr          = "New York, NY, USA"}
+
+@String{pub-OLIVER-BOYD         = "Oliver and Boyd"}
+@String{pub-OLIVER-BOYD:adr     = "Edinburgh, UK; London, UK"}
+
+@String{pub-OPEN-COURT          = "Open Court Publishing Co."}
+@String{pub-OPEN-COURT:adr      = "La Salle, IL, USA"}
+
+@String{pub-OXFORD              = "Oxford University Press"}
+@String{pub-OXFORD:adr          = "Walton Street, Oxford OX2 6DP, UK"}
+
+@String{pub-PALGRAVE-MACMILLAN  = "Palgrave Macmillan"}
+@String{pub-PALGRAVE-MACMILLAN:adr = "Houndmills, Basingstoke, Hampshire England
+                                  and New York, NY, USA"}
+
+@String{pub-PANTHEON            = "Pantheon Books"}
+@String{pub-PANTHEON:adr        = "New York, NY, USA"}
+
+@String{pub-PENGUIN             = "Penguin"}
+@String{pub-PENGUIN:adr         = "London, UK and New York, NY, USA"}
+
+@String{pub-PENGUIN-PRESS       = "Penguin"}
+@String{pub-PENGUIN-PRESS:adr   = "New York, NY, USA"}
+
+@String{pub-PENN-STATE-UNIV-PRESS = "Pennsylvania State University Press"}
+@String{pub-PENN-STATE-UNIV-PRESS:adr = "University Park, PA, USA"}
+
+@String{pub-PERGAMON            = "Pergamon"}
+@String{pub-PERGAMON:adr        = "New York, NY, USA"}
+
+@String{pub-PERSEUS             = "Perseus Publishers"}
+@String{pub-PERSEUS:adr         = "Cambridge, MA, USA"}
+
+@String{pub-PH                  = "Pren{\-}tice-Hall"}
+@String{pub-PH:adr              = "Upper Saddle River, NJ 07458, USA"}
+
+@String{pub-PHILOSOPHICAL-LIBRARY = "Philosophical Library"}
+@String{pub-PHILOSOPHICAL-LIBRARY:adr = "New York, NY, USA"}
+
+@String{pub-PLENUM              = "Plenum Press"}
+@String{pub-PLENUM:adr          = "New York, NY, USA; London, UK"}
+
+@String{pub-POCKET              = "Pocket Books"}
+@String{pub-POCKET:adr          = "New York, NY, USA"}
+
+@String{pub-PRINCETON           = "Princeton University Press"}
+@String{pub-PRINCETON:adr       = "Princeton, NJ, USA"}
+
+@String{pub-PROMETHEUS-BOOKS    = "Prometheus Books"}
+@String{pub-PROMETHEUS-BOOKS:adr = "Amherst, NY, USA"}
+
+@String{pub-PUTNAM              = "Putnam"}
+@String{pub-PUTNAM:adr          = "New York, NY, USA"}
+
+@String{pub-RANDOM-HOUSE        = "Random House"}
+@String{pub-RANDOM-HOUSE:adr    = "New York, NY, USA"}
+
+@String{pub-REIDEL              = "D. Reidel"}
+@String{pub-REIDEL:adr          = "Dordrecht, The Netherlands; Boston, MA, USA;
+                                  Lancaster, UK; Tokyo, Japan"}
+
+@String{pub-ROUTLEDGE           = "Routledge"}
+@String{pub-ROUTLEDGE:adr       = "London, UK"}
+
+@String{pub-ROWOHLT             = "Rowohlt"}
+@String{pub-ROWOHLT:adr         = "Reinbek bei Hamburg, Germany"}
+
+@String{pub-RUTGERS             = "Rutgers University Press"}
+@String{pub-RUTGERS:adr         = "New Brunswick, NJ, USA"}
+
+@String{pub-SCARECROW           = "Scarecrow Press"}
+@String{pub-SCARECROW:adr       = "Metuchen, NJ, USA"}
+
+@String{pub-SCHOCKEN-BOOKS      = "Schocken Books"}
+@String{pub-SCHOCKEN-BOOKS:adr  = "New York, NY, USA"}
+
+@String{pub-SCIENCE-HISTORY-USA = "Science History Publications/USA"}
+@String{pub-SCIENCE-HISTORY-USA:adr = "Canton, MA, USA and Sagamore Beach, MA, USA"}
+
+@String{pub-SIAM                = "SIAM Press"}
+@String{pub-SIAM:adr            = "Philadelphia, PA, USA"}
+
+@String{pub-SIMON-SCHUSTER      = "Simon and Schuster"}
+@String{pub-SIMON-SCHUSTER:adr  = "New York, NY, USA"}
+
+@String{pub-ST-MARTINS          = "St. Martin's Press"}
+@String{pub-ST-MARTINS:adr      = "New York, NY, USA"}
+
+@String{pub-STANFORD            = "Stanford University Press"}
+@String{pub-STANFORD:adr        = "Stanford, CA, USA"}
+
+@String{pub-SV                  = "Spring{\-}er-Ver{\-}lag"}
+@String{pub-SV:adr              = "Berlin, Germany~/ Heidelberg,
+                                  Germany~/ London, UK~/ etc."}
+
+@String{pub-TAYLOR-FRANCIS      = "Taylor and Francis"}
+@String{pub-TAYLOR-FRANCIS:adr  = "London, UK and Boca Raton, FL, USA"}
+
+@String{pub-TEUBNER             = "B. G. Teubner"}
+@String{pub-TEUBNER:adr         = "Stuttgart, Germany; Leipzig, Germany"}
+
+@String{pub-THREE-RIVERS        = "Three Rivers Press"}
+@String{pub-THREE-RIVERS:adr    = "New York, NY, USA"}
+
+@String{pub-TICKNOR             = "Ticknor and Fields"}
+@String{pub-TICKNOR:adr         = "New York, NY, USA"}
+
+@String{pub-TOMASH              = "Tomash Publishers"}
+@String{pub-TOMASH:adr          = "Los Angeles, CA, USA"}
+
+@String{pub-U-CAL-OHST          = "Office for History of Science and Technology,
+                                  University of California at Berkeley"}
+@String{pub-U-CAL-OHST:adr      = "Berkeley, CA, USA"}
+
+@String{pub-U-CALIFORNIA-PRESS  = "University of California Press"}
+@String{pub-U-CALIFORNIA-PRESS:adr = "Berkeley, CA, USA and Los Angeles, CA, USA"}
+
+@String{pub-U-CHICAGO           = "University of Chicago Press"}
+@String{pub-U-CHICAGO:adr       = "Chicago, IL, USA and London, UK"}
+
+@String{pub-U-COLUMBIA          = "Columbia University Press"}
+@String{pub-U-COLUMBIA:adr      = "New York, NY, USA"}
+
+@String{pub-U-LEHIGH            = "Lehigh University Press"}
+@String{pub-U-LEHIGH:adr        = "Bethlehem, PA, USA"}
+
+@String{pub-U-NC                = "University of North Carolina Press"}
+@String{pub-U-NC:adr            = "Chapel Hill, NC, USA"}
+
+@String{pub-U-NEBRASKA          = "University of Nebraska Press"}
+@String{pub-U-NEBRASKA:adr      = "Lincoln, NE, USA"}
+
+@String{pub-U-NEW-MEXICO        = "University of New Mexico Press"}
+@String{pub-U-NEW-MEXICO:adr    = "Albuquerque, NM, USA"}
+
+@String{pub-U-PENN              = "University of Pennsylvania Press"}
+@String{pub-U-PENN:adr          = "Philadelphia"}
+
+@String{pub-USGPO               = "United States Government Printing Office"}
+@String{pub-USGPO:adr           = "Washington, DC, USA"}
+
+@String{pub-VAN-NOSTRAND-REINHOLD = "Van Nostrand Reinhold"}
+@String{pub-VAN-NOSTRAND-REINHOLD:adr = "New York, NY, USA"}
+
+@String{pub-VIEWEG              = "Friedrich Vieweg und Sohn"}
+@String{pub-VIEWEG:adr          = "Braunschweig, Germany"}
+
+@String{pub-VIKING              = "Viking"}
+@String{pub-VIKING:adr          = "New York, NY, USA"}
+
+@String{pub-VINTAGE             = "Vintage Books"}
+@String{pub-VINTAGE:adr         = "New York, NY, USA"}
+
+@String{pub-VUB                 = "VUB University Press"}
+@String{pub-VUB:adr             = "Brussels, Belgium"}
+
+@String{pub-W-H-FREEMAN         = "W. H. Freeman and Company"}
+@String{pub-W-H-FREEMAN:adr     = "New York, NY, USA"}
+
+@String{pub-WALKER              = "Walker and Company"}
+@String{pub-WALKER:adr          = "435 Hudson Street, New York, NY 10014, USA"}
+
+@String{pub-WEIDENFELD-NICOLSON = "Weidenfeld and Nicolson"}
+@String{pub-WEIDENFELD-NICOLSON:adr = "London, UK"}
+
+@String{pub-WILEY               = "Wiley"}
+@String{pub-WILEY:adr           = "New York, NY, USA"}
+
+@String{pub-WILEY-VCH           = "Wiley-VCH"}
+@String{pub-WILEY-VCH:adr       = "Berlin, Germany, Weinheim, Germany, and
+                                  New York, NY, USA"}
+
+@String{pub-WORLD-SCI           = "World Scientific Publishing
+                                  Co. Pte. Ltd."}
+@String{pub-WORLD-SCI:adr       = "P. O. Box 128, Farrer Road,
+                                  Singapore 9128"}
+
+@String{pub-YALE                = "Yale University Press"}
+@String{pub-YALE:adr            = "New Haven, CT, USA"}
+
+%%% ====================================================================
+%%%               Part 1 (of 7) --- Einstein and his works
+%%%
+%%% Bibliography entries, sorted by year and then by citation key.
+@Unpublished{Einstein:1895:UAI,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber die Untersuchung des Aetherzustandes im
+                 magnetishen Felde}. ({German}). [{On} the investigation
+                 of the state of the ether in magnetic fields]",
+  pages =        "5",
+  year =         "1895",
+  bibdate =      "Mon Sep 21 15:58:18 2009",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Dated between 05/01/1895 and 09/25/1895.",
+  URL =          "http://www.alberteinstein.info/db/ViewDetails.do?DocumentID=34390",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "Mahaffey:2009:AAN (p. 51) and Gardner:1993:CMA (p. 92)
+                 cite a five-page paper written by Einstein in high
+                 school, perhaps about 1896, titled (in English
+                 translation) ``The Investigation of the State of Ether
+                 in Magnetic Fields'' or ``Concerning The Investigation
+                 of Ether in Magnetic Fields''. The Einstein Archives
+                 contain this record, which seems to correspond to those
+                 references, demonstrating that Einstein knew about the
+                 problem of the Ether, and thus, likely also the results
+                 of the Michelson--Morley Experiment before his 1905
+                 work on Special Relativity. However, the matter remains
+                 controversial: see discussion and remarks
+                 \cite{Shankland:1963:CAE,Shankland:1973:CAE,Ogawa:1979:JEE,Einstein:1982:HCT,Itagaki:1999:EKL,vanDongen:2009:RMM}.",
+}
+
+@Article{Einstein:1901:FCG,
+  author =       "A. Einstein",
+  title =        "{Folgerungen aus den Capillarit{\"a}tserscheinungen}.
+                 ({German}) [{Consequences} of the capillarity
+                 phenomenon]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "309",
+  number =       "3",
+  pages =        "513--523",
+  year =         "1901",
+  DOI =          "http://dx.doi.org/10.1002/andp.19013090306",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "This is Einstein's first published paper.",
+  ZMnumber =     "32.0816.03",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "1",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "1",
+  Whittaker-number = "1",
+  xxvolume =     "4",
+  ZMreviewer =   "Reg.-Rat Dr. Brix (Steglitz)",
+}
+
+@Article{Einstein:1902:KTW,
+  author =       "A. Einstein",
+  title =        "{Kinetische Theorie des W{\"a}rmegleichgewichtes und
+                 des zweiten Hauptsatzes der Thermodynamik}. ({German})
+                 [{Kinetic} theory of heat equilibrium and the {Second
+                 Law of Thermodynamics}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "314",
+  number =       "10",
+  pages =        "417--433",
+  year =         "1902",
+  DOI =          "http://dx.doi.org/10.1002/andp.19023141007",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "33.0911.02",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "3",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "3",
+  Whittaker-number = "3",
+  xxvolume =     "9",
+  ZMreviewer =   "Obering Rotth. (Berlin)",
+}
+
+@Article{Einstein:1902:TTP,
+  author =       "A. Einstein",
+  title =        "{{\"U}ber die thermodynamische Theorie der
+                 Potentialdifferenz zwischen Metallen und
+                 vollst{\"a}ndig dissociierten L{\"o}sungen ihrer Salze
+                 und {\"u}ber eine elektrische Methode zur Erforschung
+                 der Molekularkr{\"a}fte}. ({German}) [{On} the
+                 thermodynamic theory of the difference of potential
+                 between metals and completely dissociated solutions of
+                 their salts and more on an electrical method for the
+                 study of intermolecular forces]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "313",
+  number =       "8",
+  pages =        "798--814",
+  year =         "1902",
+  DOI =          "http://dx.doi.org/10.1002/andp.19023130806",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "33.0912.01",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "2",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "2",
+  Whittaker-number = "2",
+  xxvolume =     "8",
+  ZMreviewer =   "Obering Rotth. (Berlin)",
+}
+
+@Article{Einstein:1903:TGT,
+  author =       "A. Einstein",
+  title =        "{Eine Theorie der Grundlagen der Thermodynamik}.
+                 ({German}) [{A} theory of the foundation of
+                 thermodynamics]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "316",
+  number =       "5",
+  pages =        "170--187",
+  year =         "1903",
+  DOI =          "http://dx.doi.org/10.1002/andp.19033160510",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "34.0962.01",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "4",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "4",
+  Whittaker-number = "4",
+  xxvolume =     "11",
+  ZMreviewer =   "Obering Rotth. (Berlin)",
+}
+
+@Article{Einstein:1904:AMT,
+  author =       "A. Einstein",
+  title =        "{Zur allgemeinen molekularen Theorie der W{\"a}rme}.
+                 ({German}) [{Towards} a general molecular theory of
+                 heat]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "319",
+  number =       "7",
+  pages =        "354--362",
+  year =         "1904",
+  DOI =          "http://dx.doi.org/10.1002/andp.19043190707",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "35.0918.01",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "5",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "5",
+  Whittaker-number = "5",
+  xxvolume =     "14",
+  ZMreviewer =   "Obering Rotth. (Berlin)",
+}
+
+@Article{Einstein:1905:EBK,
+  author =       "Albert Einstein",
+  title =        "{Zur Elektrodynamik bewegter K{\"o}rper}. ({German})
+                 [{On} the electrodynamics of moving bodies]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "322",
+  number =       "10",
+  pages =        "891--921",
+  year =         "1905",
+  DOI =          "http://dx.doi.org/10.1002/andp.19053221004",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translations in
+                 \cite[35--65]{Lorentz:1952:PRC} and
+                 \cite{Schwartz:1977:EFP}.",
+  URL =          "http://www.gsjournal.net/Science-Journals/Essays/View/2492;
+                 http://www.itba.edu.ar/cargrado/fismat/fismod/transf/htm/einstein_1.htm;
+                 http://www.zbp.univie.ac.at/einstein/einstein3.pdf",
+  ZMnumber =     "36.0920.02",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "9",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  remark =       "This is the initial paper on Special Relativity. The
+                 paper was received on June 30, 1905, and published on
+                 September 26, 1905.",
+  Schilpp-number = "9",
+  Whittaker-number = "8",
+  xxnote =       "\cite{Calaprice:2004:EA} has pages 801--921.",
+  xxvolume =     "17",
+  ZMreviewer =   "Dr. Grimm (Halensee)",
+}
+
+@Article{Einstein:1905:EVL,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber einen die Erzeugung und Verwandlung des
+                 Lichtes betreffenden heuristischen Gesichtspunkt}.
+                 ({German}) [{On} the production and transformation of
+                 light from a heuristic viewpoint]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "322",
+  number =       "6",
+  pages =        "132--148",
+  year =         "1905",
+  DOI =          "http://dx.doi.org/10.1002/andp.19053220607",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in \cite{Arons:1965:EPP}.",
+  URL =          "http://www.gsjournal.net/Science-Journals/Essays/View/2490;
+                 http://www.gsjournal.net/Science-Journals/Essays/View/2491;
+                 http://www.zbp.univie.ac.at/einstein/einstein1.pdf",
+  ZMnumber =     "36.0883.01",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "6",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  received =     "18 March 1905",
+  remark =       "From Schilpp: ``This paper and item 13 present the
+                 fundamental photoelectric equation in explicit form
+                 through not in current notation. It was nominally for
+                 this work that the Nobel Prize [in Physics for 1921]
+                 was awarded [with a one-year delay in 1922] to
+                 Einstein.'' Paper published on June 9, 1905.",
+  Schilpp-number = "7",
+  Whittaker-number = "6",
+  xxvolume =     "17",
+  ZMreviewer =   "Dr. Grimm (Halensee)",
+}
+
+@Article{Einstein:1905:MTW,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber die von der molekularkinetischen Theorie der
+                 W{\"a}rme gefordert Bewegung von in ruhenden
+                 Fl{\"u}{\ss}igkeiten suspendierten Teilchen}.
+                 ({German}) [{On} the molecular-kinetic theory of the
+                 movement by heat of particles suspended in liquids at
+                 rest]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "322",
+  number =       "8",
+  pages =        "549--560",
+  year =         "1905",
+  DOI =          "http://dx.doi.org/10.1002/andp.19053220806",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See the historical overview in \cite{Haw:2002:CSB},
+                 the earlier discovery \cite{Bachelier:1900:TSF} applied
+                 to modeling of stock market fluctuations, and a simpler
+                 derivation, building on Einstein's work
+                 \cite{Langevin:1908:TDM,Lemons:1997:PLP}. See also
+                 \cite{Nye:1972:MRP} for a book-length treatment of
+                 theory and experiment of Brownian motion, particularly
+                 the careful, and numerous, experiments of Jean Perrin
+                 that demonstrated close agreement of theory with
+                 experiment, and provided credible proof of the
+                 existence of atoms and molecules. Perrin received the
+                 Nobel Prize in Physics in 1926 ``for his work on the
+                 discontinuous structure of matter, and especially for
+                 his discovery of sedimentation equilibrium''.",
+  URL =          "http://www.nobelprize.org/nobel_prizes/physics/laureates/1926/;
+                 http://www.zbp.univie.ac.at/einstein/einstein2.pdf",
+  ZMnumber =     "36.0975.01",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "8",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  received =     "11 May 1905",
+  remark =       "Paper published July 18, 1905.",
+  Schilpp-number = "8",
+  Whittaker-number = "7",
+  xxvolume =     "17",
+  ZMreviewer =   "Brix, Reg.-Rat Dr. (Steglitz)",
+}
+
+@PhdThesis{Einstein:1905:NBM,
+  author =       "Albert Einstein",
+  title =        "{Eine Neue Bestimmung der Molek{\"u}ldimensionen}.
+                 ({German}) [{A} new determination of molecular
+                 dimensions]",
+  type =         "Inaugural dissertation",
+  school =       "Bern Wyss.",
+  address =      "Bern, Switzerland",
+  year =         "1905",
+  bibdate =      "Fri Dec 17 10:46:57 2004",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Published in \cite{Einstein:1906:NBM}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  advisor =      "Alfred Kleiner (24 April 1849--3 July 1916)",
+  URL =          "http://en.wikipedia.org/wiki/Alfred_Kleiner",
+  remark =       "Received August 19, 1905 and published February 8,
+                 1906.",
+  Schilpp-number = "6",
+}
+
+@Article{Einstein:1905:TKS,
+  author =       "Albert Einstein",
+  title =        "{Ist die Tr{\"a}gheit eines K{\"o}rpers von seinem
+                 Energieinhalt abh{\"a}ngig?}. ({German}) [{Does} the
+                 inertia of a body depend on its energy content?]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "323",
+  number =       "13",
+  pages =        "639--641",
+  year =         "1905",
+  DOI =          "http://dx.doi.org/10.1002/andp.19053231314",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Fri Dec 17 10:53:36 2004",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in
+                 \cite[67--71]{Lorentz:1952:PRC}.",
+  URL =          "http://www.fourmilab.ch/etexts/einstein/E_mc2/www/;
+                 http://www.gsjournal.net/Science-Journals/Essays/View/2493;
+                 http://www.itba.edu.ar/cargrado/fismat/fismod/transf/htm/einstein_2.htm;
+                 http://www.zbp.univie.ac.at/einstein/einstein4.pdf",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "10",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  remark =       "Mailed on September 27, 1905, published on November
+                 21, 1905.",
+  Schilpp-number = "10",
+  Whittaker-number = "9",
+  xxvolume =     "18",
+}
+
+@Article{Einstein:1906:MBV,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber eine Methode zur Bestimmung des
+                 Verh{\"a}ltnisses der transversalen und longitudinalen
+                 Masse des Elektrons}. ({German}) [{On} a method for the
+                 determination of the ratio of the transverse and the
+                 longitudinal mass of electrons]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "326",
+  number =       "13",
+  pages =        "583--586",
+  year =         "1906",
+  DOI =          "http://dx.doi.org/10.1002/andp.19063261310",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 06:24:48 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "15",
+  Whittaker-number = "14",
+  xxvolume =     "21",
+}
+
+@Article{Einstein:1906:NBM,
+  author =       "Albert Einstein",
+  title =        "{Eine neue Bestimmung der Molek{\"u}ldimensionen}.
+                 ({German}) [{A} new determination of molecular
+                 dimensions]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "324",
+  number =       "2",
+  pages =        "289--306",
+  year =         "1906",
+  DOI =          "http://dx.doi.org/10.1002/andp.19063240204",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See corrections
+                 \cite{Einstein:1911:BMAa,Einstein:1911:BMAb}. This is a
+                 slightly revised version of Einstein's doctoral
+                 dissertation \cite{Einstein:1905:NBM}.",
+  ZMnumber =     "37.0811.01",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "7",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "11",
+  Whittaker-number = "10",
+  xxvolume =     "19",
+  ZMreviewer =   "Brix, Reg.-Rat Dr. (Steglitz)",
+}
+
+@Article{Einstein:1906:PES,
+  author =       "A. Einstein",
+  title =        "{Das Prinzip von der Erhaltung der
+                 Schwerpunktsbewegung und die Tr{\"a}gheit der Energie}.
+                 ({German}) [{The} principle of the preservation of the
+                 center of gravity and inertial energy]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "325",
+  number =       "8",
+  pages =        "627--633",
+  year =         "1906",
+  DOI =          "http://dx.doi.org/10.1002/andp.19063250814",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "37.0697.05",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "12",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "14",
+  Whittaker-number = "13",
+  xxvolume =     "20",
+  ZMreviewer =   "Prof. Lampe (Berlin)",
+}
+
+@Article{Einstein:1906:ORM,
+  author =       "Albert Einstein",
+  title =        "{Optik: [Rezension von] M[ax] Planck:
+                 Vorlesungen {\"u}ber die Theorie der
+                 W{\"a}rmestrahlung}. ({German}) [{Review} of {Max
+                 Planck}: {Lectures} on the theory of thermal
+                 radiation]",
+  journal =      j-BEIBL-ANN-PHYS,
+  volume =       "30",
+  number =       "15",
+  pages =        "764--766",
+  month =        "????",
+  year =         "1906",
+  CODEN =        "BEAPAI",
+  ISSN =         "0375-846X",
+  bibdate =      "Wed Aug 14 15:29:34 2013",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/p/planck-max.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://hdl.handle.net/2027/uva.x000269580?urlappend=%3Bseq=772",
+  acknowledgement = ack-nhfb,
+  ajournal =     "Beibl. Ann. Phys.",
+  fjournal =     "{Beibl{\"a}tter zu den Annalen der Physik}",
+  journal-URL =  "https://de.wikisource.org/wiki/Annalen_der_Physik#Beibl.C3.A4tter",
+  language =     "German",
+  remark =       "I cannot find this supplement, or this article, listed
+                 at the Wiley Web site for Annalen der
+                 Physik. No previous source has had this reference,
+                 which I found as the last entry in the bibliography in
+                 \cite[page 215]{Gearhart:2002:PQH}. This paper is
+                 reprinted in \cite[Document 37]{Stachel:1989:CPA} and
+                 in English translation in \cite[pages
+                 211--212]{Beck:1987:CPAb}. I finally located it online
+                 in a painfully-slow viewer at Hathi Trust.",
+}
+
+@Article{Einstein:1906:TBB,
+  author =       "A. Einstein",
+  title =        "{Zur Theorie der {\em Brownschen} Bewegung}.
+                 ({German}) [{On} the Theory of {Brownian} Motion]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "324",
+  number =       "2",
+  pages =        "371--381",
+  year =         "1906",
+  DOI =          "http://dx.doi.org/10.1002/andp.19063240208",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "37.0814.02",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "11",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "12",
+  Whittaker-number = "11",
+  xxvolume =     "19",
+  ZMreviewer =   "Brix, Reg.-Rat Dr. (Steglitz)",
+}
+
+@Article{Einstein:1906:TLL,
+  author =       "Albert Einstein",
+  title =        "{Zur Theorie der Lichterzeugung und Lichtabsorption}.
+                 ({German}) [{On} the theory of light production and
+                 light absorption]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "325",
+  number =       "6",
+  pages =        "199--206",
+  year =         "1906",
+  DOI =          "http://dx.doi.org/10.1002/andp.19063250613",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 06:18:57 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "13",
+  Whittaker-number = "12",
+  xxvolume =     "20",
+}
+
+@Article{Einstein:1907:BMA,
+  author =       "A. Einstein",
+  title =        "{Berichtigung zu meiner Arbeit: Die Plancksche Theorie
+                 der Strahlung etc.}. ({German}) [{Correction} to my
+                 paper: {``The Planck Theory of Radiation etc.''}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "327",
+  number =       "4",
+  pages =        "800--800",
+  year =         "1907",
+  DOI =          "http://dx.doi.org/10.1002/andp.19073270415",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Fri Jun 8 10:19:00 2012",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/p/planck-max.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See \cite{Einstein:1907:PTS}.",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  received =     "3 Mar 1907",
+}
+
+@Article{Einstein:1907:BNH,
+  author =       "A. Einstein",
+  title =        "{Bemerkungen zu der Notiz des Herrn {\em Paul
+                 Ehrenfest}: ``Die Translation deformierbarer Elektronen
+                 und der Fl{\"a}chensatz''}. ({German}) [{Remark} on
+                 note of {Mr. Paul Ehrenfest}: {``The translation of
+                 deformable electrons and the Area Law''}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "328",
+  number =       "6",
+  pages =        "206--208",
+  year =         "1907",
+  DOI =          "http://dx.doi.org/10.1002/andp.19073280616",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "38.0861.04",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "19",
+  Whittaker-number = "18",
+  xxvolume =     "23",
+  ZMreviewer =   "Dr. Grimm (Schmargendorf)",
+}
+
+@Article{Einstein:1907:GST,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber die G{\"u}ltigkeitsgrenze des Satzes vom
+                 thermodynamischen Gleichgewicht und {\"u}ber die
+                 M{\"o}glichkeit einer neuen Bestimmung der
+                 Elementarquanta}. ({German}) [{Validity} limits of the
+                 equation of thermodynamic equilibrium and more on the
+                 possibility of a new determination of elementary
+                 quanta]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "327",
+  number =       "3",
+  pages =        "569--572",
+  year =         "1907",
+  DOI =          "http://dx.doi.org/10.1002/andp.19073270311",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 06:35:01 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "14",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "17",
+  Whittaker-number = "16",
+  xxnote =       "\cite{Calaprice:2004:EA} has the title as ``{\"U}ber
+                 die G{\"u}ltigkeit des Satzes vom thermodynamischen
+                 Gleichgewicht und {\"u}ber die Moglichkeit einer neuen
+                 Bestimmung der Elementarquanta''.",
+  xxvolume =     "22",
+}
+
+@Article{Einstein:1907:MNP,
+  author =       "A. Einstein",
+  title =        "{{\"U}ber die M{\"o}glichkeit einer neuen Pr{\"u}fung
+                 des Relativit{\"a}tsprinzips}. ({German}) [{On} the
+                 possibility of a new proof of the {Principle of
+                 Relativity}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "328",
+  number =       "6",
+  pages =        "197--198",
+  year =         "1907",
+  DOI =          "http://dx.doi.org/10.1002/andp.19073280613",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "38.0861.01",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "18",
+  Whittaker-number = "17",
+  xxvolume =     "23",
+  ZMreviewer =   "Dr. Grimm (Schmargendorf)",
+}
+
+@Article{Einstein:1907:PTS,
+  author =       "Albert Einstein",
+  title =        "{Die Plancksche Theorie der Strahlung und die Theorie
+                 der spezifischen W{\"a}rme}. ({German}) [{Planck}'s
+                 theory of radiation and the theory of specific heat]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "327",
+  number =       "1",
+  pages =        "180--190",
+  year =         "1907",
+  DOI =          "http://dx.doi.org/10.1002/andp.19063270110",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 06:32:33 2006",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/p/planck-max.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See correction \cite{Einstein:1907:BMA}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "13",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  received =     "19 Nov 1906",
+  remark =       "See \cite[Chapter 13: Frozen
+                 Vibrations]{Stone:2013:EQQ} for a clear discussion of
+                 the significance of this paper and its short
+                 correction.",
+  Schilpp-number = "16",
+  Whittaker-number = "15",
+  xxvolume =     "22",
+}
+
+@Article{Einstein:1907:RDGa,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber das Relativit{\"a}tsprinzip und die aus
+                 demselben gezogenen Folgerungen}. ({German}) [{On} the
+                 {Relativity Principle} and the conclusions drawn from
+                 it]",
+  journal =      "Jahrbuch der Radioaktivit{\"a}t und Elektronik",
+  volume =       "4",
+  pages =        "411--462",
+  year =         "1907",
+  bibdate =      "Wed Sep 28 06:33:27 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See corrections in \cite{Einstein:1907:RDGb}. English
+                 translations in
+                 \cite[Volume~2]{Schwartz:1977:ECEa,Schwartz:1977:ECEb,Schwartz:1977:ECEc,Beck:1987:CPAa}. This
+                 is Einstein's first statement of the Principle of
+                 Equivalence.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "17a",
+  language =     "German",
+  Schilpp-number = "21a",
+  Whittaker-number = "20a",
+}
+
+@Article{Einstein:1907:RDGb,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber das Relativit{\"a}tsprinzip und die aus
+                 demselben gezogene Folgerungen}. ({German}) [{On} the
+                 {Relativity Principle} and the conclusions drawn from
+                 it]",
+  journal =      "Jahrbuch der Radioaktivit{\"a}t und Elektronik",
+  volume =       "5",
+  pages =        "98--99",
+  year =         "1907",
+  bibdate =      "Wed Sep 28 06:33:27 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "17b",
+  language =     "German",
+  Schilpp-number = "21b",
+  Whittaker-number = "20b",
+}
+
+@Article{Einstein:1907:RGT,
+  author =       "A. Einstein",
+  title =        "{{\"U}ber die vom Relativit{\"a}tsprinzip geforderte
+                 Tr{\"a}gheit der Energie}. ({German}) [{On} the
+                 inertial energy required by the {Relativity
+                 Principle}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "328",
+  number =       "7",
+  pages =        "371--384",
+  year =         "1907",
+  DOI =          "http://dx.doi.org/10.1002/andp.19073280713",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "38.0861.02",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "16",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "20",
+  Whittaker-number = "19",
+  xxvolume =     "23",
+  ZMreviewer =   "Dr. Grimm (Schmargendorf)",
+}
+
+@Article{Einstein:1907:TBB,
+  author =       "Albert Einstein",
+  title =        "{Theoretische Bemerkungen {\"u}ber die Brownsche
+                 Bewegung}. ({German}) [{Theoretical} remarks on
+                 {Brownian} motion]",
+  journal =      "Zeitschrift f{\"u}r Elektrochemie und angewandte
+                 physikalische Chemie",
+  volume =       "13",
+  number =       "6",
+  pages =        "41--42",
+  year =         "1907",
+  DOI =          "http://dx.doi.org/10.1002/bbpc.19070130602",
+  ISSN =         "0005-9021",
+  bibdate =      "Sat Oct 28 06:46:38 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  ajournal =     "Z. Elektrochem.",
+  Calaprice-number = "15",
+  language =     "German",
+  Schilpp-number = "22",
+  Whittaker-number = "21",
+}
+
+@Article{Einstein:1908:BAE,
+  author =       "Albert Einstein and Jakob Johann Laub",
+  title =        "{Berichtigung zur Abhandlung: {\"U}ber die
+                 elektromagnetischen Grundgleichungen f{\"u}r bewegte
+                 K{\"o}rper}. ({German}) [Correction to the paper: {``On
+                 the electromagnetic principal equations of moving
+                 bodies''}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "332",
+  number =       "11",
+  pages =        "232--232",
+  year =         "1908",
+  DOI =          "http://dx.doi.org/10.1002/andp.19083321115",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See \cite{Einstein:1908:EGB,Einstein:1909:BUA}",
+  ZMnumber =     "39.0910.02",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "20b",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "23b",
+  Whittaker-number = "22b",
+  xxvolume =     "27",
+  ZMreviewer =   "Dr. Grimm (Stettin)",
+}
+
+@Article{Einstein:1908:EGB,
+  author =       "Albert Einstein and Jakob Johann Laub",
+  title =        "{{\"U}ber die elektromagnetischen Grundgleichungen
+                 f{\"u}r bewegte K{\"o}rper}. ({German}) [{On} the
+                 electromagnetic principal equations of moving bodies]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "331",
+  number =       "8",
+  pages =        "532--540",
+  year =         "1908",
+  DOI =          "http://dx.doi.org/10.1002/andp.19083310806",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See correction \cite{Einstein:1908:BAE} and supplement
+                 \cite{Einstein:1909:BUA}.",
+  ZMnumber =     "39.0910.02",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "20a",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "23a",
+  Whittaker-number = "22a",
+  xxvolume =     "26",
+  ZMreviewer =   "Dr. Grimm (Stettin)",
+}
+
+@Article{Einstein:1908:ETB,
+  author =       "Albert Einstein",
+  title =        "{Elementare Theorie der Brownschen Bewegung}.
+                 ({German}) [{Elementary} Theory of {Brownian} Motion]",
+  journal =      "Zeitschrift f{\"u}r Elektrochemie und angewandte
+                 physikalische Chemie",
+  volume =       "14",
+  number =       "17",
+  pages =        "235--239",
+  year =         "1908",
+  DOI =          "http://dx.doi.org/10.1002/bbpc.19080141703",
+  ISSN =         "0005-9021",
+  bibdate =      "Sat Oct 28 06:58:26 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  ajournal =     "Z. Elektrochem.",
+  Calaprice-number = "19",
+  language =     "German",
+  Schilpp-number = "26",
+  Whittaker-number = "25",
+}
+
+@Article{Einstein:1908:IEF,
+  author =       "Albert Einstein and Jakob Johann Laub",
+  title =        "{{\"U}ber die im elektromagnetischen Felde auf ruhende
+                 K{\"o}rper ausge{\"u}bten ponderomotorischen
+                 Kr{\"a}fte}. ({German}) [{On} the ponderomotive forces
+                 exerted in the electromagnetic field on inertial
+                 bodies]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "331",
+  number =       "8",
+  pages =        "541--550",
+  year =         "1908",
+  DOI =          "http://dx.doi.org/10.1002/andp.19083310807",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "39.0910.01",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "21",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "24",
+  Whittaker-number = "23",
+  xxvolume =     "26",
+  ZMreviewer =   "Dr. Grimm (Stettin)",
+}
+
+@Article{Einstein:1908:NEM,
+  author =       "Albert Einstein",
+  title =        "{Eine neue elektrostatische Methode zur Messung
+                 kleiner Elektrizit{\"a}tsmengen}. ({German}) [{New}
+                 electrostatic method for the measurement of small
+                 electrical charges]",
+  journal =      j-PHYSIKAL-Z,
+  volume =       "9",
+  number =       "??",
+  pages =        "216--217",
+  year =         "1908",
+  bibdate =      "Sat Oct 28 06:51:26 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "18",
+  language =     "German",
+  Schilpp-number = "25",
+  Whittaker-number = "24",
+}
+
+@Article{Einstein:1909:BAD,
+  author =       "A. Einstein",
+  title =        "{Bemerkung zu der Arbeit von {\em D. Mirimanoff}:
+                 ``{\"U}ber die Grundgleichungen. \ldots''}. ({German})
+                 [{Remark} on the work of {D. Mirimanoff}: ``{On} the
+                 principal equations \ldots{}'']",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "333",
+  number =       "4",
+  pages =        "885--888",
+  year =         "1909",
+  DOI =          "http://dx.doi.org/10.1002/andp.19093330406",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "40.0929.01",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "28",
+  Whittaker-number = "27",
+  xxvolume =     "28",
+}
+
+@Article{Einstein:1909:BUA,
+  author =       "Albert Einstein and Jakob Johann Laub",
+  title =        "{Bemerkungen zu unserer Arbeit: ``{\"U}ber die
+                 elektromagnetischen Grundgleichungen f{\"u}r bewegte
+                 K{\"o}rper''}. ({German}) [{Remark} on our work: ``{On}
+                 the electromagnetic principal equations of moving
+                 bodies'']",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "333",
+  number =       "2",
+  pages =        "445--447",
+  year =         "1909",
+  DOI =          "http://dx.doi.org/10.1002/andp.19093330212",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See \cite{Einstein:1908:EGB,Einstein:1908:BAE}.",
+  ZMnumber =     "40.0926.02",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "20c",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "27",
+  Whittaker-number = "26",
+  xxvolume =     "28",
+  ZMreviewer =   "Dr. Grimm (Stettin)",
+}
+
+@Article{Einstein:1909:EUAa,
+  author =       "A. Einstein",
+  title =        "{{\"U}ber die Entwicklung unserer Anschauungen
+                 {\"u}ber das Wesen und die Konstitution der Strahlung}.
+                 ({German}) [{On} the development of our views about the
+                 nature and constitution of radiation]",
+  journal =      j-VERH-DTSCH-PHYS-GES,
+  volume =       "11",
+  number =       "20",
+  pages =        "482--500",
+  day =          "30",
+  month =        oct,
+  year =         "1909",
+  CODEN =        "VDPEAZ",
+  ISSN =         "0372-5448",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Republished in \cite{Einstein:1909:EUAb}.",
+  ZMnumber =     "40.0984.03",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "23a",
+  fjournal =     "{Verhandlungen der Deutschen Physikalischen
+                 Gesellschaft}",
+  journal-URL =  "http://catalog.hathitrust.org/Record/012306260",
+  language =     "German",
+  remark =       "According to \cite[page 136]{Stone:2013:EQQ}, this
+                 paper is from a lecture delivered on 21 September 1909
+                 in Salzburg, Austria, to the Deutsche Gesellschaft der
+                 Naturforscher und Arzte before an audience of about
+                 100, including Max Planck, Max Born, Wilhelm Wien, Max
+                 von Laue, and others, most of whom Einstein had never
+                 before seen in person, having only gotten his first
+                 academic job in May 1909, at Universit{\"a}t
+                 Z{\"u}rich. It may have been the first time Einstein
+                 attended a scientific conference. In his talk, Einstein
+                 did not mention Relativity, but came out strongly in
+                 favor of Planck's quantum, and the wave--particle
+                 duality of light.",
+  Schilpp-number = "30a",
+  Whittaker-number = "29a",
+  ZMreviewer =   "Prof. Lampe (Berlin)",
+}
+
+@Article{Einstein:1909:EUAb,
+  author =       "A. Einstein",
+  title =        "{{\"U}ber die Entwicklung unserer Anschauungen
+                 {\"u}ber das Wesen und die Konstitution der Strahlung}.
+                 ({German}) [{On} the development of our views about the
+                 nature and constitution of radiation]",
+  journal =      j-PHYSIKAL-Z,
+  volume =       "10",
+  number =       "??",
+  pages =        "817--826",
+  year =         "1909",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Republication of \cite{Einstein:1909:EUAa}.",
+  ZMnumber =     "40.0984.03",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "23b",
+  language =     "German",
+  Schilpp-number = "30b",
+  Whittaker-number = "29b",
+  ZMreviewer =   "Prof. Lampe (Berlin)",
+}
+
+@Article{Einstein:1909:GSS,
+  author =       "Albert Einstein",
+  title =        "{Zum gegenw{\"a}rtigen Stande des Strahlungsproblems}.
+                 ({German}) [{On} the current state of the radiation
+                 problem]",
+  journal =      j-PHYSIKAL-Z,
+  volume =       "10",
+  number =       "??",
+  pages =        "185--193",
+  year =         "1909",
+  bibdate =      "Sat Oct 28 07:02:21 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "22a",
+  language =     "German",
+  Schilpp-number = "29",
+  Whittaker-number = "28",
+  xxtitle =      "{Zum gegenw{\"a}rtigen Stand des Strahlungsproblems}.
+                 ({German}) [{On} the current state of the radiation
+                 problem]",
+}
+
+@Article{Ritz:1909:GSSb,
+  author =       "W. Ritz and A. Einstein",
+  title =        "{Zum gegenw{\"a}rtigen Stande des Strahlungsproblems}.
+                 ({German}) [{On} the current state of the radiation
+                 problem]",
+  journal =      j-PHYSIKAL-Z,
+  volume =       "10",
+  number =       "??",
+  pages =        "323--324",
+  month =        "????",
+  year =         "1909",
+  CODEN =        "PHZTAO",
+  ISSN =         "0369-982X",
+  bibdate =      "Thu Jul 25 15:53:01 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See
+                 \cite{Einstein:1909:GSS,Ritz:1909:GSSa,Fox:1965:EAE}.",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Physikalische Zeitschrift",
+  language =     "German",
+}
+
+@Misc{Einstein:190x:TGG,
+  author =       "Albert Einstein",
+  title =        "{Tangentenbussole und Galvanometer}. ({German})
+                 [{Tangent} Galvanometer and Galvanometer]",
+  howpublished = "Matura Examination (D) Physics",
+  year =         "190x",
+  bibdate =      "Thu Jul 25 15:14:00 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "Cited in \cite[page 325, reference 4]{Maas:2007:EEC}.
+                 What year??",
+}
+
+@Misc{Einstein:1910:ETE,
+  author =       "Albert Einstein",
+  title =        "{Einf{\"u}hrung in die Theorie der Elektrizit{\"a}t
+                 und des Magnetismus. Z{\"u}rich, Wintersemester
+                 1910--1911}. ({German}) [{Lecture} Notes for Course on
+                 Electricity and Magnetism at the {University of Zurich,
+                 Winter Semester 1910--1911}]",
+  howpublished = "Unpublished, but reproduced in \cite[pages
+                 316--396]{Klein:1993:CPA}.",
+  year =         "1910",
+  bibdate =      "Thu Jul 25 15:35:36 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1910:FPQ,
+  author =       "Albert Einstein",
+  title =        "Les forces pond{\'e}romotrices qui agissent sur les
+                 conducteurs ferromagn{\'e}tiques dispos{\'e}s dans un
+                 champ magn{\'e}tique et parcourus par un courant.
+                 ({French}) [{Ponderomotive} (inertial??) forces which
+                 act on the ferromagnetic drivers laid out in a magnetic
+                 field and traversed by a current]",
+  journal =      "Arch. Sci. phys. nat. (4)",
+  volume =       "30",
+  number =       "??",
+  pages =        "323--324",
+  year =         "1910",
+  bibdate =      "Sat Oct 28 07:15:20 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "22b, 26",
+  fjournal =     "Archives des sciences physiques et naturelles, 4.
+                 s{\'e}ries",
+  language =     "French",
+  Schilpp-number = "36",
+  Whittaker-number = "35",
+  xxnote =       "\cite{Calaprice:2004:EA} claims this appears in
+                 j-PHYSIKAL-Z volume 10, with second author Walter
+                 Ritz.",
+}
+
+@Article{Einstein:1910:PRSa,
+  author =       "Albert Einstein",
+  title =        "Le principe de relativit{\'e} et ses cons{\'e}quences
+                 dans la physique moderne. ({French}) [{The Principle of
+                 Relativity} and Its Consequences in Modern Physics]",
+  journal =      "Arch. Sci. phys. nat. (4)",
+  volume =       "29",
+  number =       "??",
+  pages =        "5--28",
+  year =         "1910",
+  bibdate =      "Sat Oct 28 07:08:45 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "24a",
+  fjournal =     "Archives des sciences physiques et naturelles, 4.
+                 s{\'e}ries",
+  language =     "French",
+  Schilpp-number = "34a",
+  Whittaker-number = "33a",
+}
+
+@Article{Einstein:1910:PRSb,
+  author =       "Albert Einstein",
+  title =        "Le principe de relativit{\'e} et ses cons{\'e}quences
+                 dans la physique moderne. ({French}) [{The Principle of
+                 Relativity} and Its Consequences in Modern Physics]",
+  journal =      "Arch. Sci. phys. nat. (4)",
+  volume =       "29",
+  number =       "??",
+  pages =        "125--244",
+  year =         "1910",
+  bibdate =      "Sat Oct 28 07:08:45 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "24b",
+  fjournal =     "Archives des sciences physiques et naturelles, 4.
+                 s{\'e}ries",
+  language =     "French",
+  Schilpp-number = "34b",
+  Whittaker-number = "33b",
+}
+
+@Article{Einstein:1910:SUB,
+  author =       "A. Einstein and L. Hopf",
+  title =        "{Statistische Untersuchung der Bewegung eines
+                 Resonators in einem Strahlungsfeld}. ({German})
+                 [{Statistical} investigation of the movement of
+                 resonators in a radiation field]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "338",
+  number =       "16",
+  pages =        "1105--1115",
+  year =         "1910",
+  DOI =          "http://dx.doi.org/10.1002/andp.19103381604",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "41.0999.03",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "28",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "32",
+  Whittaker-number = "31",
+  xxvolume =     "33",
+  ZMreviewer =   "Reg.-Rat Dr. Brix (Friedenau)",
+}
+
+@Article{Einstein:1910:SWS,
+  author =       "A. Einstein and L. Hopf",
+  title =        "{{\"U}ber einen Satz der Wahrscheinlichkeitsrechnung
+                 und seine Anwendung in der Strahlungstheorie}.
+                 ({German}) [{On} a theorem of probability calculation
+                 and its application in radiation theory]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "338",
+  number =       "16",
+  pages =        "1096--1104",
+  year =         "1910",
+  DOI =          "http://dx.doi.org/10.1002/andp.19103381603",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "41.0999.02",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "27",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "31",
+  Whittaker-number = "30",
+  xxvolume =     "33",
+  ZMreviewer =   "Reg.-Rat Dr. Brix (Friedenau)",
+}
+
+@Article{Einstein:1910:TOH,
+  author =       "A. Einstein",
+  title =        "{Theorie der Opaleszenz von homogenen
+                 Fl{\"u}ssigkeiten und Fl{\"u}ssigkeitsgemischen in der
+                 N{\"a}he des kritischen Zustandes}. ({German})
+                 [{Theory} of opalescence of homogeneous liquids and
+                 liquid mixtures near the critical state]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "338",
+  number =       "16",
+  pages =        "1275--1298",
+  year =         "1910",
+  DOI =          "http://dx.doi.org/10.1002/andp.19103381612",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "41.0927.02",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "29",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "33",
+  Whittaker-number = "32",
+  xxvolume =     "33",
+  ZMreviewer =   "Dr. Grimm (Stettin)",
+}
+
+@Article{Einstein:1910:TQL,
+  author =       "Albert Einstein",
+  title =        "Sur la th{\'e}orie des quantit{\'e}s lumineuses et la
+                 question de la localisation de l'{\'e}nergie
+                 {\'e}lectromagn{\'e}tique. ({French}) [{On} the theory
+                 of luminous quantities and the question of the
+                 localization of electromagnetic energy]",
+  journal =      "Arch. Sci. phys. nat. (4)",
+  volume =       "29",
+  number =       "??",
+  pages =        "525--528",
+  year =         "1910",
+  bibdate =      "Sat Oct 28 07:12:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "25",
+  fjournal =     "Archives des sciences physiques et naturelles, 4.
+                 s{\'e}ries",
+  language =     "French",
+  Schilpp-number = "35",
+  Whittaker-number = "34",
+}
+
+@Article{Einstein:1911:BGE,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung zu dem Gesetz von E{\"o}tv{\"o}s}.
+                 ({German}) [{Remark} on the {Law of E{\"o}tv{\"o}s}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "339",
+  number =       "1",
+  pages =        "165--169",
+  year =         "1911",
+  DOI =          "http://dx.doi.org/10.1002/andp.19113390109",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 07:20:59 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "37",
+  Whittaker-number = "36",
+  xxvolume =     "34",
+}
+
+@Article{Einstein:1911:BMAa,
+  author =       "A. Einstein",
+  title =        "{Bemerkung zu meiner Arbeit: Eine Beziehung zwischen
+                 dem elastischen Verhalten}. ({German}) [{Remark} on my
+                 paper: {``A relationship between the elastic behavior
+                 \ldots{}''}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "339",
+  number =       "3",
+  pages =        "590--590",
+  year =         "1911",
+  DOI =          "http://dx.doi.org/10.1002/andp.19113390312",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Fri Jun 8 10:31:29 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See \cite{Einstein:1911:BZE}",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+}
+
+@Article{Einstein:1911:BMAb,
+  author =       "Albert Einstein",
+  title =        "{Berichtigung zu meiner Arbeit: Eine neue Bestimmung
+                 der Molek{\"u}ldimensionen}. ({German}) [{Corrections}
+                 to my work: a new determination of molecular
+                 dimensions]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "339",
+  number =       "3",
+  pages =        "591--592",
+  year =         "1911",
+  DOI =          "http://dx.doi.org/10.1002/andp.19113390313",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 07:30:27 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See \cite{Einstein:1906:NBM}.",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "40",
+  Whittaker-number = "39",
+  xxvolume =     "34",
+}
+
+@Article{Einstein:1911:BPH,
+  author =       "Albert Einstein",
+  title =        "{Bermerkungen zu den P. Hertzschen Arbeiten:
+                 Mechanische Grundlagen der Thermodynamik}. ({German})
+                 [{Remarks} on the work of {P. Hertz: ``Mechanical Bases
+                 of Thermodynamics}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "339",
+  number =       "1",
+  pages =        "175--176",
+  year =         "1911",
+  DOI =          "http://dx.doi.org/10.1002/andp.19113390111",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 07:28:19 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "39",
+  Whittaker-number = "38",
+  xxvolume =     "34",
+}
+
+@Article{Einstein:1911:BZE,
+  author =       "Albert Einstein",
+  title =        "{Eine Beziehung zwischen dem elastischen Verhalten und
+                 der spezifischen W{\"a}rme bei festen K{\"o}rpen mit
+                 einatomigem Molek{\"u}l}. ({German}) [{A} relationship
+                 between the elastic behavior and the specific heat of
+                 solid bodies with monatomic molecules]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "339",
+  number =       "1",
+  pages =        "170--174, 590",
+  year =         "1911",
+  DOI =          "http://dx.doi.org/10.1002/andp.19113390110",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 07:23:40 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See remarks
+                 \cite{Einstein:1911:BMAa,Einstein:1911:BMAb}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "30",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "38",
+  Whittaker-number = "37",
+  xxvolume =     "34",
+}
+
+@Article{Einstein:1911:EBT,
+  author =       "Albert Einstein",
+  title =        "{Elementare Betrachtungen {\"u}ber die thermische
+                 Molekularbewegung in festen K{\"o}rpern}. ({German})
+                 [{Elementary} Observations on the Thermomolecular
+                 Motions of Inertial Bodies]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "340",
+  number =       "9",
+  pages =        "679--694",
+  year =         "1911",
+  DOI =          "http://dx.doi.org/10.1002/andp.19113400903",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 07:33:44 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "32",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "41",
+  Whittaker-number = "40",
+  xxvolume =     "34",
+}
+
+@Article{Einstein:1911:EPB,
+  author =       "A. Einstein",
+  title =        "{Zum {\em Ehrenfest}schen Paradoxon. Bemerkung zu {\em
+                 V. Varicaks} Aufsatz}. ({German}) [{On} the {Ehrenfest}
+                 paradox: Remark on {V. Varicaks}'s essay]",
+  journal =      j-PHYSIKAL-Z,
+  volume =       "12",
+  number =       "??",
+  pages =        "509--510",
+  year =         "1911",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "42.0727.02",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "44",
+  Whittaker-number = "42",
+  ZMreviewer =   "Prof. Lampe (Berlin)",
+}
+
+@Article{Einstein:1911:ESA,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber den Einflu{\ss} der Schwerkraft auf die
+                 Ausbreitung des Lichtes}. ({German}) [{On} the
+                 influence of gravitation on the propagation of light]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "340",
+  number =       "10",
+  pages =        "898--908",
+  year =         "1911",
+  DOI =          "http://dx.doi.org/10.1002/andp.19113401005",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in \cite[Volume~3]{Beck:1987:CPAa}
+                 and \cite[97--108]{Lorentz:1952:PRC}.",
+  URL =          "http://www.itba.edu.ar/cargrado/fismat/fismod/transf/htm/einstein_5.htm",
+  ZMnumber =     "42.0852.01",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "33",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  remark =       "According to Miller \cite[page 101]{Miller:1999:EFS},
+                 ``In 1911, he found a means to test his ideas on
+                 gravitation by predicting the bending of light rays in
+                 the field of a gravitational point source'' [citation
+                 of this paper]. See also \cite{Soldner:1921:BAL}, a
+                 reprint of 1804",
+  Schilpp-number = "42",
+  Whittaker-number = "41",
+  xxvolume =     "35",
+  ZMreviewer =   "Dr. Seeliger (Charlottenburg)",
+}
+
+@Article{Einstein:1911:RGT,
+  author =       "A. Einstein",
+  title =        "{Die Relativit{\"a}tstheorie}. ({German}) [{The}
+                 Theory of Relativity]",
+  journal =      j-VJSCHR-NATURF-GES-ZURICH,
+  volume =       "56",
+  number =       "??",
+  pages =        "1--14",
+  year =         "1911",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "42.0720.02",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "31",
+  language =     "German",
+  Schilpp-number = "43",
+  ZMreviewer =   "Prof. Lampe (Berlin)",
+}
+
+@Article{Einstein:1912:ABJ,
+  author =       "Albert Einstein",
+  title =        "{Antwort auf eine Bemerkung von J. Stark: {\"U}ber
+                 eine Anwendung des Planckschen Elementargesetzes}.
+                 ({German}) [{Answer} to a remark of {J. Stark}:
+                 ``{Application} of {Planck}'s Fundamental Law'']",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "343",
+  number =       "9",
+  pages =        "888--888",
+  day =          "30",
+  month =        may,
+  year =         "1912",
+  DOI =          "http://dx.doi.org/10.1002/andp.19123430912",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 07:45:20 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "48",
+  Whittaker-number = "46",
+  xxpages =      "171--??",
+  xxvolume =     "38",
+}
+
+@Article{Einstein:1912:BAV,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung zu Abrahams vorangehender
+                 Auseinandersetzung: Nochmals Relativit{\"a}t und
+                 Gravitation}. ({German}) [{Remark} on {Abrahams}'
+                 preceding argument: {Relativity} and gravitation
+                 again]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "344",
+  number =       "13",
+  pages =        "704--704",
+  month =        aug,
+  year =         "1912",
+  DOI =          "http://dx.doi.org/10.1002/andp.19123441311",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 07:48:55 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "50",
+  Whittaker-number = "48",
+  xxvolume =     "39",
+}
+
+@InProceedings{Einstein:1912:EAD,
+  author =       "Albert Einstein",
+  title =        "{{\'E}}tat actuel du probl{\`e}me des chaleurs
+                 sp{\'e}cifiques. ({French}) [{Current} state of the
+                 problem of specific heat]",
+  crossref =     "Langevin:1912:GWH",
+  pages =        "407--435 + 436--450 (discussion)",
+  year =         "1912",
+  bibdate =      "Sat Sep 05 15:42:58 2015",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+  Schilpp-number = "51",
+  Whittaker-number = "49",
+}
+
+@Article{Einstein:1912:GGE,
+  author =       "Albert Einstein",
+  title =        "{Gibt es eine Gravitationswirkung, die der
+                 elektrodynamischen Induktionswirkung Analog ist?}.
+                 ({German}) [{Given} that there is a gravitational
+                 effect on electrodynamics, is the induction effect
+                 similar?]",
+  journal =      "{Vierteljahrsschrift f{\"u}r gerichtliche Medizin und
+                 {\"o}ffentliches Sanit{\"a}tswesen (3)}",
+  volume =       "44",
+  number =       "??",
+  pages =        "37--40",
+  year =         "1912",
+  bibdate =      "Sat Oct 28 07:53:33 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  ajournal =     "Vjschr. gericht. Med. (3)",
+  Calaprice-number = "38",
+  fjournal =     "Vierteljahrsschrift f{\"u}r gerichtliche Medizin,
+                 series 3",
+  language =     "German",
+  Schilpp-number = "52",
+  Whittaker-number = "50",
+}
+
+@Article{Einstein:1912:LSG,
+  author =       "Albert Einstein",
+  title =        "{Lichtgeschwindigkeit und Statik des
+                 Gravitationsfeldes}. ({German}) [{Speed} of light and
+                 statics of the gravitational field]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "343",
+  number =       "7",
+  pages =        "355--369",
+  year =         "1912",
+  DOI =          "http://dx.doi.org/10.1002/andp.19123430704",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 07:42:45 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "36",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "46",
+  Whittaker-number = "44",
+  xxvolume =     "38",
+}
+
+@Article{Einstein:1912:NMA,
+  author =       "Albert Einstein",
+  title =        "{Nachtrag zu meiner Arbeit: `Thermodynamische
+                 Begr{\"u}ndung des photochemischen
+                 {\"A}quivalentgesetzes'}. ({German}) [{Supplement} to
+                 My Paper: {`Thermodynamic Grounds for the Law of
+                 Photochemical Equivalence'}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "343",
+  number =       "9",
+  pages =        "881--884",
+  month =        "????",
+  year =         "1912",
+  DOI =          "http://dx.doi.org/10.1002/andp.19123430910",
+  bibdate =      "Fri Jun 08 06:38:02 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://onlinelibrary.wiley.com/doi/10.1002/andp.19123430910/abstract",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+}
+
+@Article{Einstein:1912:RGE,
+  author =       "Albert Einstein",
+  title =        "{Relativit{\"a}t und Gravitation: Erwiderung auf eine
+                 Bemerkung von M. Abraham}. ({German}) [{Relativity} and
+                 gravitation: Retort on a remark of {M. Abraham}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "343",
+  number =       "10",
+  pages =        "1059--1064",
+  year =         "1912",
+  DOI =          "http://dx.doi.org/10.1002/andp.19123431014",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 07:47:26 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "49",
+  Whittaker-number = "47",
+  xxvolume =     "38",
+}
+
+@Article{Einstein:1912:TBPa,
+  author =       "Albert Einstein",
+  title =        "{Thermodynamische Begr{\"u}ndung des photochemischen
+                 {\"A}quivalentgesetzes}. ({German}) [{Thermodynamic}
+                 reasons for the photochemical {Law of Equivalence}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "342",
+  number =       "4",
+  pages =        "832--838",
+  year =         "1912",
+  DOI =          "http://dx.doi.org/10.1002/andp.19123420413",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 07:40:21 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "35",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "45a",
+  Whittaker-number = "43a",
+  xxvolume =     "37",
+}
+
+@Article{Einstein:1912:TBPb,
+  author =       "Albert Einstein",
+  title =        "{Thermodynamische Begr{\"u}ndung des photochemischen
+                 {\"A}quivalentgesetzes}. ({German}) [{Thermodynamic}
+                 reasons for the {Law of Photochemical Equivalence}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "38",
+  number =       "??",
+  pages =        "881--884",
+  year =         "1912",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 07:40:21 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "45b",
+  Whittaker-number = "43b",
+}
+
+@Article{Einstein:1912:TSG,
+  author =       "Albert Einstein",
+  title =        "{Zur Theorie des statischen Gravitationsfeldes}.
+                 ({German}) [{Theory} of Statistical Gravity Fields]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "343",
+  number =       "7",
+  pages =        "443--458",
+  year =         "1912",
+  DOI =          "http://dx.doi.org/10.1002/andp.19123430709",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 07:43:45 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Also {Nachtrag zur Korrektur} (Addendum for the
+                 correction) in same volume.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "37",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "47",
+  Whittaker-number = "45",
+  xxvolume =     "38",
+}
+
+@Article{Einstein:1913:DTL,
+  author =       "Albert Einstein",
+  title =        "{D}{\'e}duction thermodynamique de la loi de
+                 l'{\'e}quivalence photochimique. ({French})
+                 [{Thermodynamic} deduction of the {Law of Photochemical
+                 Equivalence}]",
+  journal =      "Journal de physique (3)",
+  volume =       "3",
+  number =       "??",
+  pages =        "277--282",
+  year =         "1913",
+  bibdate =      "Sat Oct 28 08:02:42 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  ajournal =     "J. Phys. (5)",
+  Calaprice-number = "39",
+  language =     "French",
+  Schilpp-number = "55",
+  Whittaker-number = "53",
+  xxjournal =    "Journal de physique (5)",
+}
+
+@Article{Einstein:1913:EAA,
+  author =       "Albert Einstein and Otto Stern",
+  title =        "{Einige Argumente f{\"u}r die Annahme einer molekular
+                 Agitation beim absoluten Nullpunkt}. ({German}) [{Some}
+                 Arguments for the Acceptance of Molecular Motion at
+                 Absolute Zero]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "345",
+  number =       "3",
+  pages =        "551--560",
+  year =         "1913",
+  DOI =          "http://dx.doi.org/10.1002/andp.19133450309",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 07:59:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  keywords =     "Nullpunktsenergie; zero-point energy",
+  language =     "German",
+  Schilpp-number = "54",
+  Whittaker-number = "52",
+  xxvolume =     "40",
+}
+
+@Book{Einstein:1913:EVRa,
+  author =       "Albert Einstein and Marcel Grossmann",
+  title =        "{Entwurf einer verallgemeinerten
+                 Relativit{\"a}tstheorie und eine Theorie der
+                 Gravitation}. ({German}) [{Outline} of a {Generalized
+                 Relativity Theory} and a {Theory of Gravitation}]",
+  publisher =    pub-TEUBNER,
+  address =      pub-TEUBNER:adr,
+  pages =        "38",
+  year =         "1913",
+  LCCN =         "????",
+  bibdate =      "Fri Jun 15 16:22:48 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "1. Physikalische Teil von Albert Einstein in
+                 Z{\"u}rich. 2. Mathematische Teil von Marcel
+                 Grossmann.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "First Physical part by Albert Einstein in Zurich.
+                 Second Mathematical part by Marcel Grossmann.",
+}
+
+@Article{Einstein:1913:EVRb,
+  author =       "Albert Einstein and Marcel Grossmann",
+  title =        "{Entwurf einer verallgemeinerten
+                 Relativit{\"a}tstheorie und eine Theorie der
+                 Gravitation}. ({German}) [{Outline} of a {Generalized
+                 Relativity Theory} and a {Theory of Gravitation}]",
+  journal =      "Zeitschrift f{\"u}r Mathematik und Physik",
+  volume =       "62",
+  number =       "??",
+  pages =        "225--261",
+  year =         "1913",
+  bibdate =      "Sat Oct 28 07:57:16 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprint of \cite{Einstein:1913:EVRa}.",
+  acknowledgement = ack-nhfb,
+  ajournal =     "Z. Math. Phys.",
+  Calaprice-number = "40",
+  language =     "German",
+  remark-1 =     "See
+                 \cite{Earman:1978:LTE,Stachel:1980:ESG,Norton:1984:HEF}
+                 for historical reviews of the development of the field
+                 equations of General Relativity that began this paper,
+                 which appeared first as a separatum published by
+                 Teubner in Leipzig in the same year
+                 \cite{Einstein:1913:EVRa}; \cite{Calaprice:2004:EA}
+                 cites it that way.",
+  remark-2 =     "Janssen \cite[page 58]{Janssen:2005:PHE} says this
+                 paper was published in this journal in 1914, a year
+                 later than the Teubner book, but that seems to be
+                 incorrect, compared to other sources and library
+                 catalogs that show volume 63 in 1914, and volume 64 in
+                 1917. Alas, the journal was published only from 1856 to
+                 1917, and it does not appear to have an online archive
+                 from which we could verify the year. Whittaker
+                 \cite[page 62]{Whittaker:1955:AE} definitely says 1913,
+                 and Schilpp lists both in the 1913 section of his
+                 bibliography.",
+  Schilpp-number = "53",
+  Whittaker-number = "51",
+}
+
+@Article{Einstein:1913:GGT,
+  author =       "Albert Einstein",
+  title =        "{Gravitationstheorie}. ({German}) [{Theory} of
+                 Gravitation]",
+  journal =      "{Schweizerische Naturforschende Gesellschaft.
+                 Verhandlungen}",
+  volume =       "96",
+  number =       "2",
+  pages =        "??--??",
+  month =        "????",
+  year =         "1913",
+  bibdate =      "Fri Jun 08 06:47:23 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1913:GSP,
+  author =       "Albert Einstein",
+  title =        "{Zum gegenw{\"a}rtigen Stande des Problems der
+                 spezifischen W{\"a}rme}. ({German}) [{On} the present
+                 state of the problem of specific heat]",
+  journal =      "Abhandlungen der Deutsche Bunsengesellschaft",
+  volume =       "??",
+  number =       "7",
+  pages =        "330--364",
+  year =         "1913",
+  bibdate =      "Mon Oct 30 07:43:26 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "German edition of the Proceedings of the First Solvay
+                 Conference; see \cite{Einstein:1912:EAD}. Republished
+                 in \cite{Einstein:1914:GSP}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "34a",
+  language =     "German",
+  Schilpp-number = "63",
+}
+
+@Article{Einstein:1913:GZG,
+  author =       "Albert Einstein",
+  title =        "{Zum gegenw{\"a}rtigen Zustande des
+                 Gravitationsproblems}. ({German}) [{On} the present
+                 state of the problem of gravitation]",
+  journal =      j-PHYSIKAL-Z,
+  volume =       "14",
+  number =       "??",
+  pages =        "1249--1266",
+  year =         "1913",
+  bibdate =      "Sat Oct 28 08:06:56 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "42",
+  language =     "German",
+  Schilpp-number = "58",
+  Whittaker-number = "55",
+  xxnote =       "\cite{Calaprice:2004:EA} says pages 1249--1262.",
+}
+
+@Article{Einstein:1913:HLR,
+  author =       "Albert Einstein",
+  title =        "{H. A. Lorentz: Das Relativit{\"a}tsprinzip}.
+                 ({German}) [{Review} of {H. A. Lorentz: {\em The
+                 Principle of Relativity}}]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "2",
+  number =       "??",
+  pages =        "1018--1018",
+  year =         "1913",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Mon Oct 30 07:48:00 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "66",
+}
+
+@Article{Einstein:1913:MPF,
+  author =       "Albert Einstein",
+  title =        "{Max Planck als Forscher}. ({German}) [{Max Planck} as
+                 Researcher]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "1",
+  number =       "45",
+  pages =        "1077--1079",
+  day =          "7",
+  month =        nov,
+  year =         "1913",
+  CODEN =        "NATWAY",
+  DOI =          "http://dx.doi.org/10.1007/BF01493259",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Mon Oct 30 07:30:46 2006",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/p/planck-max.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite[561--563]{Klein:1996:CPA}.",
+  URL =          "http://link.springer.com/article/10.1007/BF01493259",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "43",
+  fjournal =     "Naturwissenschaften",
+  journal-URL =  "http://link.springer.com/journal/114",
+  language =     "German",
+  Schilpp-number = "57",
+  subject-dates = "April 23, 1858 -- October 4, 1947",
+}
+
+@Article{Einstein:1913:NGS,
+  author =       "Albert Einstein and Adriaan Daniel Fokker",
+  title =        "{Die Nordstr{\"o}msche Gravitationstheorie vom
+                 Standpunkt des absoluten Differentialkalk{\"u}ls}.
+                 ({German}) [{Nordstr{\"o}m} gravitation theory from the
+                 viewpoint of absolute differential calculus]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "349",
+  number =       "10",
+  pages =        "321--328",
+  year =         "1913",
+  DOI =          "http://dx.doi.org/10.1002/andp.19143491009",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 08:11:14 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "59",
+  Whittaker-number = "56",
+  xxvolume =     "44",
+}
+
+@Article{Einstein:1913:PGG,
+  author =       "Albert Einstein",
+  title =        "{Physikalische Grundlagen einer Gravitationstheorie}.
+                 ({German}) [{Physical} Basis of a {Theory of
+                 Gravitation}]",
+  journal =      j-VJSCHR-NATURF-GES-ZURICH,
+  volume =       "58",
+  number =       "??",
+  pages =        "284--290",
+  year =         "1913",
+  bibdate =      "Sat Oct 28 08:04:37 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Lecture given on 9 September 1913 to the Ninety-Sixth
+                 Annual Meeting of the Schweizerische Naturgesellschaft
+                 (Swiss Society of Natural Scientists) in Frauenfeld,
+                 Switzerland.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "41",
+  language =     "German",
+  Schilpp-number = "56",
+  Whittaker-number = "54",
+}
+
+@Book{Lorentz:1913:RGP,
+  author =       "Hendrik Antoon Lorentz and Albert Einstein and Hermann
+                 Minkowski",
+  title =        "{Das Relativit{\"a}tsprinzip}. ({German}) [{The
+                 Principle of Relativity}]",
+  volume =       "2",
+  publisher =    "Verlag Teubner",
+  address =      "Leipzig, Germany",
+  pages =        "89",
+  year =         "1913",
+  bibdate =      "Wed Dec 31 16:43:49 2008",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Edited by Otto Blumenthal.",
+  series =       "{Fortschritte der mathematischen Wissenschaften in
+                 Monographien}",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "Reprinted in 1920, 1922, 1923, 1958, 1982, and 1990.",
+}
+
+@Unpublished{Einstein:1914:AEG,
+  author =       "Albert Einstein and Georg Nicolai and Wilhelm Foerster
+                 and Otto Buek",
+  title =        "{Aufrauf an die Europ{\"a}er}. ({German}) [{Manifesto}
+                 to the {Europeans}]",
+  month =        oct,
+  year =         "1914",
+  bibdate =      "Thu Jul 15 08:58:40 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "This was issued in opposition to the just-started war
+                 in Europe, and was widely circulated in Germany. It was
+                 finally published as the introduction to Nicolai's 1917
+                 book, ``The Biology of War''
+                 \cite{Nicolai:1917:BKB,Nicolai:1918:BW,Nicolai:1919:BKB}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "51",
+  language =     "German",
+}
+
+@Article{Einstein:1914:AGI,
+  author =       "Albert Einstein",
+  title =        "{Antrittsrede}. ({German}) [{Inaugural} lecture:
+                 Principles of Theoretical Physics]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-2,
+  volume =       "??",
+  number =       "??",
+  pages =        "739--742",
+  year =         "1914",
+  bibdate =      "Mon Oct 30 07:51:15 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Included in the book {\em Mein Weltbild}. English
+                 translation in \cite[pp.~220--223]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "49",
+  language =     "German",
+  Schilpp-number = "69",
+  xxnote =       "\cite{Calaprice:2004:EA} says pages are 732--742.",
+}
+
+@Article{Einstein:1914:ARP,
+  author =       "Albert Einstein",
+  title =        "{Antwort auf eine Replik P. Harzers (Nr. 4753, S. 10
+                 und 11)}. ({German}) [{Answer} to a Reply of {P.
+                 Harzer} (No. 4753, pp. 10--11)]",
+  journal =      j-ASTRO-NACHR,
+  volume =       "199",
+  number =       "3",
+  pages =        "47--48",
+  year =         "1914",
+  CODEN =        "ASNAAN",
+  DOI =          "http://dx.doi.org/10.1002/asna.19141990304",
+  ISSN =         "0004-6337",
+  ISSN-L =       "0004-6337",
+  bibdate =      "Sat Oct 28 08:16:38 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Astronomische Nachrichten",
+  language =     "German",
+  Schilpp-number = "62",
+  Whittaker-number = "58",
+}
+
+@Article{Einstein:1914:BGC,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung}. ({German}) [{Comments} on {``Outline of a
+                 Generalized Theory of Relativity and of a Theory of
+                 Gravitation''}]",
+  journal =      "Zeitschrift f{\"u}r Mathematik und Physik",
+  volume =       "62",
+  number =       "??",
+  pages =        "??--??",
+  month =        "????",
+  year =         "1914",
+  CODEN =        "????",
+  ISSN =         "????",
+  bibdate =      "Fri Jun 08 06:55:25 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1914:BPH,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung zu P. Harzers Abhandlung: {\"U}ber die
+                 Mitf{\"u}hrung des Lichtes in Glas und die Aberration
+                 (A. N. 4748)}. ({German}) [{Remark} on {P. Harzers}'
+                 paper: {``The transmission of light in glass and its
+                 aberration'' (A. N. 4748)}]",
+  journal =      j-ASTRO-NACHR,
+  volume =       "199",
+  number =       "1",
+  pages =        "7--10",
+  year =         "1914",
+  CODEN =        "ASNAAN",
+  DOI =          "http://dx.doi.org/10.1002/asna.19141990104",
+  ISSN =         "0004-6337",
+  ISSN-L =       "0004-6337",
+  bibdate =      "Sat Oct 28 08:13:39 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://www.gsjournal.net/Science-Journals/Essays/View/4232",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Astronomische Nachrichten",
+  language =     "German",
+  Schilpp-number = "61",
+  Whittaker-number = "57",
+  xxpages =      "8--10",
+}
+
+@Article{Einstein:1914:BPT,
+  author =       "Albert Einstein",
+  title =        "Base physiques d'une th{\'e}orie de la gravitation.
+                 ({French}) [{Physical} basis of a {theory of
+                 Gravitation}]",
+  journal =      "Arch. Sci. phys. nat. (4)",
+  volume =       "37",
+  number =       "??",
+  pages =        "5--12",
+  year =         "1914",
+  bibdate =      "Mon Oct 30 07:34:22 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "French translation by E. Guillaume of
+                 \cite{Einstein:1913:PGG}.",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Archives des sciences physiques et naturelles, 4.
+                 s{\'e}ries",
+  language =     "French",
+  Schilpp-number = "60",
+}
+
+@Article{Einstein:1914:BQG,
+  author =       "Albert Einstein",
+  title =        "{Beitr{\"a}ge zur Quantentheorie}. ({German})
+                 [{Contributions} to Quantum Theory]",
+  journal =      "Ber. dtsch. phys. Ges.",
+  volume =       "16",
+  number =       "??",
+  pages =        "820--828",
+  year =         "1914",
+  bibdate =      "Sat Oct 28 08:17:57 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "50",
+  fjournal =     "Deutsche physikalische Gesellschaft, Berichte",
+  language =     "German",
+  Schilpp-number = "64",
+  Whittaker-number = "59",
+}
+
+@Article{Einstein:1914:FGA,
+  author =       "Albert Einstein",
+  title =        "Die formale Grundlage der allgemeinen
+                 Relativit{\"a}tstheorie. ({German}) [{The} formal basis
+                 of the {Theory of General Relativity}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-2,
+  volume =       "??",
+  number =       "??",
+  pages =        "1030--1085",
+  year =         "1914",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "47",
+  language =     "German",
+  remark =       "Janssen \cite[page 59]{Janssen:2005:PHE} says of this
+                 paper that Einstein wrote in a letter to Paul Ehrenfest
+                 on 26 December 1915 ``Es ist bequem mit dem Einstein.
+                 Jedes Jahr widerruft er, was er das vorige Jahr
+                 geschrieben hat.'' [it's convenient with that fellow
+                 Einstein, every year he retracts what he wrote the year
+                 before].",
+  Schilpp-number = "70",
+  Whittaker-number = "63",
+}
+
+@Article{Einstein:1914:GGT,
+  author =       "Albert Einstein",
+  title =        "{Gravitationstheorie}. ({German}) [{Theory of
+                 Gravitation}]",
+  journal =      "Verhandlungen der Schweizerische naturforschende
+                 Gesellschaft, part 2",
+  volume =       "??",
+  number =       "??",
+  pages =        "137--138",
+  year =         "1914",
+  bibdate =      "Mon Oct 30 07:58:51 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Same lecture as in \cite{Einstein:1913:PGG}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "73",
+}
+
+@InCollection{Einstein:1914:GSP,
+  author =       "Albert Einstein",
+  editor =       "Arnold Eucken",
+  booktitle =    "{Die Theorie der Strahlung und der Quanten}.
+                 ({German}) [{The} Theory of Radiation and the
+                 Quantum]",
+  title =        "{Zum gegenw{\"a}rtigen Stande des Problems der
+                 spezifischen W{\"a}rme}. ({German}) [{On} the present
+                 state of the problem of specific heat]",
+  publisher =    "Knapp",
+  address =      "Halle a.s., Germany",
+  pages =        "330--352",
+  year =         "1914",
+  bibdate =      "Mon Oct 30 07:43:26 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Republication of \cite{Einstein:1913:GSP}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "34b",
+  language =     "German",
+  Schilpp-number = "63",
+}
+
+@Article{Einstein:1914:KFV,
+  author =       "Albert Einstein and Marcel Grossmann",
+  title =        "{Kovarienzeigenschaften der Feldgleichungen der auf
+                 die verallgemeinerte Relativit{\"a}tstheorie
+                 gegr{\"u}ndeten Gravitationstheorie}. ({German})
+                 [{Covariance} Properties in the Field Equations of
+                 Gravitation Theory based on the {Generalized Theory of
+                 Relativity}]",
+  journal =      "Zeitschrift f{\"u}r Mathematik und Physik",
+  volume =       "63",
+  number =       "??",
+  pages =        "215--225",
+  year =         "1914",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  ajournal =     "Z. Math. Phys.",
+  Calaprice-number = "48",
+  language =     "German",
+  Schilpp-number = "75",
+  Whittaker-number = "65",
+}
+
+@Article{Einstein:1914:MPD,
+  author =       "Albert Einstein",
+  title =        "{M{\'e}thode} pour la d{\'e}termination de valeurs
+                 statistiques d'observations concernant des grandeurs
+                 soumises {\`a} des fluctuations irr{\'e}guli{\`e}res.
+                 ({French}) [Method for the Determination of Statistical
+                 Values of Observations Regarding Quantities Subject to
+                 Irregular Fluctuations]",
+  journal =      "Archives des sciences physiques et naturelles",
+  volume =       "37",
+  number =       "??",
+  pages =        "254--256",
+  month =        "????",
+  year =         "1914",
+  CODEN =        "????",
+  ISSN =         "????",
+  bibdate =      "Fri Jun 08 06:12:19 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in \cite{Einstein:1987:MDS}.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Article{Einstein:1914:MSV,
+  author =       "Albert Einstein",
+  title =        "{Eine Methode zur statistischen Verwertung von
+                 Beobachtungen scheinbar unregelm{\"a}ssig
+                 quasiperiodisch verlaufender Vorg{\"a}nge}. ({German})
+                 [{A} Method for the Statistical Use of Observations of
+                 Apparently Irregular, Quasiperiodic Processes ]",
+  journal =      "????",
+  volume =       "??",
+  number =       "??",
+  pages =        "603--??",
+  day =          "28",
+  month =        feb,
+  year =         "1914",
+  bibdate =      "Fri Jun 08 07:00:34 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "Mentioned in table of contents for",
+}
+
+@Article{Einstein:1914:NAF,
+  author =       "Albert Einstein",
+  title =        "{Nachtr{\"a}gliche Antwort auf eine Frage von
+                 Rei{\ss}ner}. ({German}) [{Additional} answer to a
+                 question of {Reissner}]",
+  journal =      j-PHYSIKAL-Z,
+  volume =       "15",
+  number =       "??",
+  pages =        "108--110",
+  year =         "1914",
+  bibdate =      "Sat Oct 28 08:24:55 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "67",
+  Whittaker-number = "61",
+}
+
+@Article{Einstein:1914:PGL,
+  author =       "Albert Einstein",
+  title =        "{Physikalische Grundlagen und leitende Gedanken
+                 f{\"u}r eine Gravitationstheorie}. ({German})
+                 [{Physical} basis and leading thoughts for a {Theory of
+                 Gravitation}]",
+  journal =      "Verhandlungen der Schweizerische naturforschende
+                 Gesellschaft, part 2",
+  volume =       "96",
+  number =       "??",
+  pages =        "146--146",
+  year =         "1914",
+  bibdate =      "Mon Oct 30 07:53:18 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Title only. Lecture delivered at the 96th session of
+                 the Swiss Natural Science Research Society, 19
+                 September, 1913. Same lecture as in
+                 \cite{Einstein:1913:PGG}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "72",
+}
+
+@Article{Einstein:1914:PVR,
+  author =       "Albert Einstein",
+  title =        "{Prinzipielles zur verallgemeinerten
+                 Relativit{\"a}tstheorie und Gravitationstheorie}.
+                 ({German}) [{Principles} of {Generalized Relativity
+                 Theory} and {Theory of Gravitation}]",
+  journal =      j-PHYSIKAL-Z,
+  volume =       "15",
+  number =       "??",
+  pages =        "176--180",
+  year =         "1914",
+  bibdate =      "Sat Oct 28 08:26:28 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "44",
+  language =     "German",
+  Schilpp-number = "68",
+  Whittaker-number = "62",
+}
+
+@Article{Einstein:1914:RGP,
+  author =       "Albert Einstein",
+  title =        "{Relativit{\"a}tsprinzip}. ({German}) [{The Principle
+                 of Relativity}]",
+  journal =      "{Die Vossische Zeitung}",
+  pages =        "33--34",
+  day =          "26",
+  month =        apr,
+  year =         "1914",
+  bibdate =      "Mon Oct 30 08:00:52 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "Schilpp says: ``A rather full and serious popular
+                 presentation''.",
+  Schilpp-number = "74",
+}
+
+@Article{Einstein:1914:RGT,
+  author =       "Albert Einstein",
+  title =        "{Zum Relativit{\"a}tsproblem}. ({German}) [{Toward}
+                 the {Problem of Relativity}]",
+  journal =      "Scientia (Bologna)",
+  volume =       "15",
+  number =       "??",
+  pages =        "337--348",
+  year =         "1914",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "46",
+  language =     "German",
+  Schilpp-number = "71",
+  Whittaker-number = "64",
+  xxpages =      "332--348",
+}
+
+@Article{Einstein:1914:TGG,
+  author =       "Albert Einstein",
+  title =        "{Zur Theorie der Gravitation}. ({German}) [{Toward} a
+                 {Theory of Gravitation}]",
+  journal =      j-VJSCHR-NATURF-GES-ZURICH,
+  volume =       "59",
+  number =       "2",
+  pages =        "4--6",
+  year =         "1914",
+  bibdate =      "Sat Oct 28 08:19:06 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "45",
+  language =     "German",
+  Schilpp-number = "65",
+  Whittaker-number = "60",
+}
+
+@Article{Einstein:1915:AAM,
+  author =       "Albert Einstein",
+  title =        "{Antwort auf eine Abhandlung M. von Laues: Ein Satz
+                 der Wahrscheinlichkeitsrechnung und seine Anwendung auf
+                 die Strahlungstheorie}. ({German}) [{Answer} to a paper
+                 of {M. von Laue}: {``A theory of probability
+                 calculation and its application to radiation
+                 theory''}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "352",
+  number =       "15",
+  pages =        "879--885",
+  year =         "1915",
+  DOI =          "http://dx.doi.org/10.1002/andp.19153521503",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "79",
+  Whittaker-number = "66",
+  xxvolume =     "47",
+}
+
+@Article{Einstein:1915:ARG,
+  author =       "Albert Einstein",
+  title =        "{Zur allgemeinen Relativit{\"a}tstheorie}. ({German})
+                 [{Toward} a {General Theory of Relativity}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-2,
+  volume =       "??",
+  number =       "??",
+  pages =        "778--786, 799--801",
+  year =         "1915",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "55",
+  language =     "German",
+  Schilpp-number = "83",
+  Whittaker-number = "68",
+}
+
+@Article{Einstein:1915:ENAa,
+  author =       "Albert Einstein and Wander Johannes de Haas",
+  title =        "{Experimenteller Nachweis der Amp{\`e}reschen
+                 Molekularstr{\"o}me}. ({German}) [{Experimental} proof
+                 of the {Amp{\'e}re} molecular currents]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "3",
+  number =       "??",
+  pages =        "237--238",
+  year =         "1915",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Mon Oct 30 08:17:39 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "A preliminary note about \cite{Einstein:1915:ENAb}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "81",
+}
+
+@Article{Einstein:1915:ENAb,
+  author =       "Albert Einstein and Wander Johannes de Haas",
+  title =        "{Experimenteller Nachweis der Amp{\`e}reschen
+                 Molekularstr{\"o}me}. ({German}) [{Experimental} proof
+                 of the {Amp{\'e}re} molecular currents]",
+  journal =      j-VERH-DTSCH-PHYS-GES,
+  volume =       "17",
+  number =       "8",
+  pages =        "152--170",
+  day =          "30",
+  month =        apr,
+  year =         "1915",
+  CODEN =        "VDPEAZ",
+  ISSN =         "0372-5448",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See correction \cite{Einstein:1915:BMG}. See also
+                 Dutch translation in \cite{Einstein:1915:PBV} and
+                 English translation in \cite{Einstein:1916:EPE}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "52",
+  fjournal =     "{Verhandlungen der Deutschen Physikalischen
+                 Gesellschaft}",
+  journal-URL =  "http://catalog.hathitrust.org/Record/012306260",
+  language =     "German",
+  Schilpp-number = "80",
+  Whittaker-number = "67",
+}
+
+@Article{Einstein:1915:BMG,
+  author =       "Albert Einstein",
+  title =        "{Berichtigung zu meiner gemeinsam mit Herrn J. W. de
+                 Haas ver{\"o}ffentlichten Arbeit ,,Experimenteller
+                 Nachweis der Amp{\`e}reschen Molekularstr{\"o}me''}.
+                 ({German}) [{Correction} to my collaborative published
+                 work with {Mr J. W. de Haas} {``Experimental proof of
+                 {Amp{\`e}re}'s molecular currents''}]",
+  journal =      j-VERH-DTSCH-PHYS-GES,
+  volume =       "17",
+  number =       "10",
+  pages =        "203--203",
+  day =          "30",
+  month =        may,
+  year =         "1915",
+  CODEN =        "VDPEAZ",
+  ISSN =         "0372-5448",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See \cite{Einstein:1915:ENAb}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "52",
+  fjournal =     "{Verhandlungen der Deutschen Physikalischen
+                 Gesellschaft}",
+  journal-URL =  "http://catalog.hathitrust.org/Record/012306260",
+  language =     "German",
+  Schilpp-number = "80",
+  Whittaker-number = "67",
+}
+
+@Article{Einstein:1915:EPE,
+  author =       "Albert Einstein and Wander Johannes de Haas",
+  title =        "Experimental Proof of the Existence of {Amp{\'e}re}'s
+                 Molecular Currents",
+  journal =      "Koninklijke Akademie van Wetenschappen te Amsterdam:
+                 Proceedings",
+  volume =       "18",
+  pages =        "696--711",
+  year =         "1915--1916",
+  bibdate =      "Thu Jul 15 09:22:50 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "53",
+  remark =       "Calaprice \cite{Calaprice:2004:EA} says that this
+                 journal contains a correction to
+                 \cite{Einstein:1915:ENAa}, and a later comment on this
+                 article. Find them!",
+}
+
+@Article{Einstein:1915:EPM,
+  author =       "Albert Einstein",
+  title =        "{Erkl{\"a}rung der Perihelbewegung des Merkur aus der
+                 allgemeinen Relativit{\"a}tstheorie}. ({German})
+                 [{Explanation} of the perihelical motion of {Mercury}
+                 from the {General Theory of Relativity}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-2,
+  volume =       "??",
+  number =       "??",
+  pages =        "831--839",
+  year =         "1915",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "56",
+  language =     "German",
+  Schilpp-number = "84",
+  Whittaker-number = "69",
+}
+
+@Article{Einstein:1915:FGG,
+  author =       "Albert Einstein",
+  title =        "{Die Feldgleichungen der Gravitation}. ({German})
+                 [{The} Field Equations of Gravitation]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-2,
+  volume =       "??",
+  number =       "??",
+  pages =        "844--847",
+  year =         "1915",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "57",
+  language =     "German",
+  Schilpp-number = "85",
+  Whittaker-number = "70",
+}
+
+@Article{Einstein:1915:GAR,
+  author =       "Albert Einstein",
+  title =        "{Grundgedanken der allgemeinen Relativit{\"a}tstheorie
+                 und Anwendung dieser Theorie in Astronomie}. ({German})
+                 [{Basic} idea of the {General Theory of Relativity} and
+                 Application of this Theory in Astronomy]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "??",
+  number =       "??",
+  pages =        "315--315",
+  year =         "1915",
+  bibdate =      "Mon Oct 30 08:20:36 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Abstract only. Published in full in
+                 \cite{Einstein:1915:ARG,Einstein:1915:EPM}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "82",
+}
+
+@Unpublished{Einstein:1915:MMK,
+  author =       "Albert Einstein",
+  title =        "{Meine Meinung {\"u}ber den Krieg}. ({German}) [{My}
+                 Opinion of the War]",
+  month =        oct # "\slash " # nov,
+  year =         "1915",
+  bibdate =      "Thu Jul 15 09:27:33 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Published later in \cite{Einstein:1916:MMK}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "54a",
+  language =     "German",
+}
+
+@Article{Einstein:1915:PBV,
+  author =       "Albert Einstein and Wander Johannes de Haas",
+  title =        "{Proefondervindelijk beijs voor het bestaan der
+                 moleculaire stroomen van Amp{\`e}re}. ({Dutch})
+                 [{Experimental} proof of the {Amp{\'e}re} molecular
+                 currents]",
+  journal =      "Verslag Akademi van wetenschappen, Amsterdam, series
+                 4",
+  volume =       "23",
+  number =       "??",
+  pages =        "1449--1464",
+  year =         "1915",
+  bibdate =      "Mon Oct 30 08:07:48 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Dutch translation of \cite{Einstein:1915:ENAb}. See
+                 also English translation in \cite{Einstein:1916:EPE},",
+  acknowledgement = ack-nhfb,
+  language =     "Dutch",
+  Schilpp-number = "78",
+}
+
+@InCollection{Einstein:1915:RGT,
+  author =       "Albert Einstein",
+  booktitle =    "{Die Kultur der Gegenwart. Ihre Entwicklung und ihre
+                 Ziele. Paul Hinneberg, ed. Part 3, Mathematik,
+                 Naturwissenschaften, Medizin. Section 3, Anorganischen
+                 Naturwissenschaften}",
+  title =        "{Relativit{\"a}tstheorie}. ({German}) [{Theory of
+                 Relativity}]",
+  publisher =    pub-TEUBNER,
+  address =      pub-TEUBNER:adr,
+  pages =        "703--713",
+  year =         "1915",
+  bibdate =      "Mon Oct 30 08:03:42 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See Schilpp number 192 for a revised edition.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "77",
+  xxbooktitle =  "Die Physik",
+}
+
+@InCollection{Einstein:1915:TAG,
+  author =       "A. Einstein",
+  editor =       "Emil Warburg",
+  booktitle =    "{Die Kultur der Gegenwart. Ihre Entwicklung und ihre
+                 Ziele. Paul Hinneberg, ed. Part 3, Mathematik,
+                 Naturwissenschaften, Medizin. Section 3, Anorganischen
+                 Naturwissenschaften}",
+  title =        "{Theoretische Atomistik}. ({German}) [{Theoretical}
+                 Atomism]",
+  volume =       "1",
+  publisher =    pub-TEUBNER,
+  address =      pub-TEUBNER:adr,
+  pages =        "251--263",
+  year =         "1915",
+  LCCN =         "????",
+  bibdate =      "Wed Dec 14 05:41:24 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "{Die Physik}",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "58",
+  language =     "German",
+  remark =       "Calaprice \cite{Calaprice:2004:EA} says that this was
+                 first written in 1913, published in this paper in 1915,
+                 and again in 1925 in a second edition.",
+  Schilpp-number = "76",
+  xxbooktitle =  "Die Physik",
+}
+
+@Article{Einstein:1916:EAU,
+  author =       "Albert Einstein",
+  title =        "{Einege anschauliche {\"U}berlegungen aus dem Gebiete
+                 der Relativit{\"a}tstheorie}. ({German}) [{Some}
+                 descriptive considerations from the areas of
+                 {Relativity Theory}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "??",
+  number =       "??",
+  pages =        "423--423",
+  year =         "1916",
+  bibdate =      "Mon Oct 30 08:43:16 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "98",
+}
+
+@Article{Einstein:1916:EEN,
+  author =       "Albert Einstein",
+  title =        "{Einfaches Experiment zum Nachweis der Amp{\`e}reschen
+                 Molekularstr{\"o}me}. ({German}) [{Simple} experiment
+                 for the proof of the {Amp{\`e}re} molecular stream]",
+  journal =      j-VERH-DTSCH-PHYS-GES,
+  volume =       "18",
+  number =       "6--7",
+  pages =        "173--177",
+  day =          "15",
+  month =        apr,
+  year =         "1916",
+  CODEN =        "VDPEAZ",
+  ISSN =         "0372-5448",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "{Verhandlungen der Deutschen Physikalischen
+                 Gesellschaft}",
+  journal-URL =  "http://catalog.hathitrust.org/Record/012306260",
+  language =     "German",
+  Schilpp-number = "91",
+  Whittaker-number = "73",
+}
+
+@Article{Einstein:1916:EM,
+  author =       "A. Einstein",
+  title =        "{Ernst Mach}",
+  journal =      j-PHYSIKAL-Z,
+  volume =       "17",
+  number =       "??",
+  pages =        "101--104",
+  month =        "????",
+  year =         "1916",
+  CODEN =        "PHZTAO",
+  ISSN =         "0369-982X",
+  bibdate =      "Wed Dec 14 05:40:27 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "65",
+  language =     "German",
+  Schilpp-number = "96",
+}
+
+@Article{Einstein:1916:EPE,
+  author =       "Albert Einstein and Wander Johannes de Haas",
+  title =        "Experimental Proof of the Existence of {Amp{\'e}re}'s
+                 Molecular Currents",
+  journal =      "Verslag Akademi van wetenschappen, Amsterdam, series
+                 4",
+  volume =       "18",
+  number =       "??",
+  pages =        "696--711",
+  year =         "1916",
+  bibdate =      "Mon Oct 30 08:34:59 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation of \cite{Einstein:1915:ENAb}. See
+                 also Dutch translation in \cite{Einstein:1915:PBV}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "88",
+}
+
+@Article{Einstein:1916:ETW,
+  author =       "Albert Einstein",
+  title =        "{Elementare Theorie der Wasserwellen und des Fluges}.
+                 ({German}) [{Elementary} theory of water waves and of
+                 flight]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "4",
+  number =       "??",
+  pages =        "509--510",
+  year =         "1916",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "64",
+  language =     "German",
+  Schilpp-number = "95",
+  Whittaker-number = "76",
+}
+
+@Article{Einstein:1916:FKA,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber Friedrich Kottlers Abhandlung: ``{\"U}ber
+                 Einsteins {\"A}quivalenzhypothese und die
+                 Gravitation''}. ({German}) [{On Fr. Kottlers}'s paper:
+                 {``On Einstein's Equivalence Hypothesis and
+                 Gravitation''}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "356",
+  number =       "22",
+  pages =        "639--642",
+  year =         "1916",
+  DOI =          "http://dx.doi.org/10.1002/andp.19163562206",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "90",
+  Whittaker-number = "72",
+  xxvolume =     "51",
+}
+
+@Article{Einstein:1916:GARa,
+  author =       "Albert Einstein",
+  title =        "{Die Grundlagen der Allgemeinene
+                 Relativit{\"a}tstheorie}. ({German}) [{The} Foundations
+                 of the {Theory of General Relativity}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "354",
+  number =       "7",
+  pages =        "769--822",
+  month =        "????",
+  year =         "1916",
+  DOI =          "http://dx.doi.org/10.1002/andp.19163540702",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Wed Dec 14 06:35:54 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "60",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  remark =       "This paper is consider the first complete exposition
+                 of the General Theory of Relativity.",
+  Schilpp-number = "89",
+  Whittaker-number = "71",
+  xxvolume =     "49",
+}
+
+@Book{Einstein:1916:GARb,
+  author =       "Albert Einstein",
+  title =        "{Grundlage der allgemeinen Relativit{\"a}tstheorie}.
+                 ({German}) [{The} Foundations of the {Theory of General
+                 Relativity}]",
+  publisher =    "Johann Ambrosius Barth",
+  address =      "Leipzig, Germany",
+  pages =        "64",
+  year =         "1916",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 08:25:42 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See English translation in \cite{Einstein:1920:PRO}
+                 and French translation in \cite{Einstein:1933:FTR}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "86",
+}
+
+@Article{Einstein:1916:GKS,
+  author =       "Albert Einstein",
+  title =        "{Ged{\"a}chtnisrede auf Karl Schwarzschild}.
+                 ({German}) [{Memorial} Speech for {Karl Schwarzschild}
+                 (1873--1916)]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "??",
+  number =       "??",
+  pages =        "768--770",
+  year =         "1916",
+  bibdate =      "Mon Oct 30 08:52:08 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "According to a Wikipedia biography, Schwarzschild may
+                 have died of an illness contracted while serving in
+                 Russia during World War I, or of a rare metabolic
+                 disorder. Two properties of black holes have been given
+                 his name: the Schwarzschild metric and the
+                 Schwarzschild radius.",
+  Schilpp-number = "100",
+}
+
+@Article{Einstein:1916:HLT,
+  author =       "Albert Einstein",
+  title =        "{H. A. Lorentz: Th{\'e}ories statistiques en
+                 thermodynamique}. ({German}) [{Review} of {H. A.
+                 Lorentz: {\em Statistical Theories in
+                 Thermodynamics}}]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "4",
+  number =       "??",
+  pages =        "480--481",
+  year =         "1916",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Mon Oct 30 08:41:05 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "94",
+}
+
+@Article{Einstein:1916:HPA,
+  author =       "Albert Einstein",
+  title =        "{Hamiltonsches Prinzip und allgemeine
+                 Relativit{\"a}tstheorie}. ({German}) [{Hamilton's
+                 Principle and General Relativity Theory}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-2,
+  volume =       "??",
+  number =       "??",
+  pages =        "1111--1116",
+  year =         "1916",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "Janssen \cite[page 59]{Janssen:2005:PHE} says of this
+                 paper ``[a gem] on the relation between invariance of
+                 the action integral and energy-momentum conservation,
+                 \ldots{}.''",
+  Schilpp-number = "101",
+  Whittaker-number = "79",
+}
+
+@InCollection{Einstein:1916:MMK,
+  author =       "Albert Einstein",
+  editor =       "Isidor Landau and Eugen Zabel",
+  booktitle =    "{Das Land Goethes 1914--1916: ein vaterl{\"a}ndisches
+                 Gedenkbuch}. ({German}) [{The} Land of {Goethes}
+                 1914--1916: A Patriotic Memorial Book]",
+  title =        "{Meine Meinung {\"u}ber den Krieg}. ({German}) [{My}
+                 Opinion of the War]",
+  publisher =    "Deutsche Verlags-Anstalt",
+  address =      "Stuttgart and Berlin, Germany",
+  bookpages =    "ix + 136",
+  pages =        "????",
+  month =        oct # "\slash " # nov,
+  year =         "1916",
+  bibdate =      "Thu Jul 15 09:30:06 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "54b",
+  language =     "German",
+}
+
+@Article{Einstein:1916:NFD,
+  author =       "Albert Einstein",
+  title =        "{Eine neue formale Deutung der Maxwellschen
+                 Feldgleichungen der Elektrodynamik}. ({German}) [{A}
+                 new formal interpretation of the {Maxwell} field
+                 equations of electrodynamics]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "??",
+  number =       "??",
+  pages =        "184--187",
+  year =         "1916",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "59",
+  language =     "German",
+  Schilpp-number = "97",
+  Whittaker-number = "77",
+}
+
+@Article{Einstein:1916:NIF,
+  author =       "Albert Einstein",
+  title =        "{N{\"a}herungsweise Integration der Feldgleichungen
+                 der Gravitation}. ({German}) [{Approximate} Integration
+                 of the Field Equations of Gravitation]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "??",
+  number =       "??",
+  pages =        "688--696",
+  year =         "1916",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "61",
+  language =     "German",
+  remark =       "Janssen \cite[page 59]{Janssen:2005:PHE} says of this
+                 paper ``[a gem] on gravitational waves \ldots{}.",
+  Schilpp-number = "99",
+  Whittaker-number = "77",
+}
+
+@Article{Einstein:1916:QSG,
+  author =       "Albert Einstein",
+  title =        "{Zur Quantentheorie der Strahlung}. ({German}) [{On}
+                 the {Quantum Theory of Radiation}]",
+  journal =      "Mitt. phys. Ges. Z{\"u}rich",
+  volume =       "16",
+  number =       "??",
+  pages =        "47--62",
+  year =         "1916",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Republished in \cite{Einstein:1917:QSG}. English
+                 translation in \cite{Einstein:1967:QTR}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "63a",
+  language =     "German",
+  remark =       "From \cite[page 385]{Straumann:2011:FSC}, ``The
+                 missing fluctuations in the Einstein--Hopf
+                 fluctuation-dissipation relation were found by Einstein
+                 five years after the Solvay congress, when he studied
+                 in one of his great papers again the Brownian motion of
+                 an atom or molecule in the radiation field. The first
+                 part of his famous paper [Einstein 1916 [this one]] is
+                 known to all physicists, because it contains a purely
+                 quantum derivation of Planck's distribution, and also
+                 the theoretical foundations of the laser. He thereby
+                 introduced the hitherto unknown process of induced
+                 emission, next to the familiar ones of spontaneous
+                 emission and induced absorption.''",
+  Schilpp-number = "93",
+  Whittaker-number = "75",
+}
+
+@Article{Einstein:1916:SEA,
+  author =       "Albert Einstein",
+  title =        "{Strahlungs-Emission und -Absorption nach der
+                 Quantentheorie}. ({German}) [{Radiation} emission and
+                 absorption according to quantum theory]",
+  journal =      j-VERH-DTSCH-PHYS-GES,
+  volume =       "18",
+  number =       "13--14",
+  pages =        "318--323",
+  day =          "30",
+  month =        jul,
+  year =         "1916",
+  CODEN =        "VDPEAZ",
+  ISSN =         "0372-5448",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "62",
+  fjournal =     "{Verhandlungen der Deutschen Physikalischen
+                 Gesellschaft}",
+  journal-URL =  "http://catalog.hathitrust.org/Record/012306260",
+  language =     "German",
+  Schilpp-number = "92",
+  Whittaker-number = "74",
+}
+
+@InCollection{Einstein:1916:VGF,
+  author =       "Albert Einstein",
+  title =        "{Vorwort}. ({German}) [{Foreword}]",
+  crossref =     "Freundlich:1916:GEG",
+  pages =        "??--??",
+  year =         "1916",
+  bibdate =      "Mon Oct 30 08:33:05 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "87",
+}
+
+@Article{Einstein:1917:AS,
+  author =       "Albert Einstein",
+  title =        "{Alexander von Sch{\"u}tz}",
+  journal =      j-VERH-DTSCH-PHYS-GES,
+  volume =       "19",
+  number =       "5--6",
+  pages =        "41--41",
+  day =          "30",
+  month =        mar,
+  year =         "1917",
+  CODEN =        "VDPEAZ",
+  ISSN =         "0372-5448",
+  bibdate =      "Tue Sep 08 10:47:16 2015",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "{Verhandlungen der Deutschen Physikalischen
+                 Gesellschaft}",
+  journal-URL =  "http://hdl.handle.net/2027/coo.31924056113289",
+  language =     "German",
+}
+
+@Article{Einstein:1917:ATG,
+  author =       "Albert Einstein",
+  title =        "{Der Angst-Traum}. ({German}) [{The} Nightmare]",
+  journal =      "Berliner Tageblatt",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "25",
+  month =        dec,
+  year =         "1917",
+  bibdate =      "Thu Jul 15 09:59:43 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "This essay proposes abolishing high school final
+                 examinations.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1917:ATJ,
+  author =       "Albert Einstein",
+  title =        "{Eine Ableitung des Theorems von Jacobi}. ({German})
+                 [{A} derivative of the theorem of {Jacobi}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-2,
+  volume =       "??",
+  number =       "??",
+  pages =        "606--608",
+  year =         "1917",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "108",
+  Whittaker-number = "84",
+}
+
+@Article{Einstein:1917:HVH,
+  author =       "Albert Einstein",
+  title =        "{H. v. Helmholtz: Zwei Vortr{\"a}ge {\"u}ber Goethe}.
+                 ({German}) [{H. v. Helmholtz}: {Two} lectures on
+                 {Goethe}]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "5",
+  number =       "??",
+  pages =        "675--675",
+  year =         "1917",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Mon Oct 30 08:57:02 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "104",
+}
+
+@Article{Einstein:1917:KBA,
+  author =       "Albert Einstein",
+  title =        "{Kosmologische Betrachtungen zur allgemeinen
+                 Relativit{\"a}tstheorie}. ({German}) [{Cosmological}
+                 Considerations in the {General Theory of Relativity}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "??",
+  number =       "??",
+  pages =        "142--152",
+  year =         "1917",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in
+                 \cite{Einstein:1986:CCG,Kox:1996:CPA}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "67",
+  language =     "German",
+  remark-1 =     "This is Einstein's first paper on cosmological, and
+                 the one in which he added a ``cosmological constant'',
+                 $\Lambda$, to permit the equations to describe a static
+                 universe. He later referred to that addition as his
+                 greatest blunder, and retracted it in
+                 \cite{Einstein:1931:KPA}. Research by Edwin Hubble
+                 \cite{Hubble:1929:RBD} had shown that the universe is
+                 expanding, and the constant is unnecessary.",
+  remark-2 =     "Janssen \cite[page 59]{Janssen:2005:PHE} says of this
+                 paper ``[a gem] which [sic] launched relativistic
+                 cosmology and introduced the cosmological constant,
+                 \ldots{}''.",
+  Schilpp-number = "107",
+  Whittaker-number = "83",
+}
+
+@Article{Einstein:1917:MSG,
+  author =       "Albert Einstein",
+  title =        "{Marian von Smoluchowski [1872--1917]}. ({German})
+                 [{Marian von Smoluchowski} [1872--1917]]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "5",
+  number =       "??",
+  pages =        "737--738",
+  year =         "1917",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Mon Oct 30 08:59:49 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "See
+                 \url=http://hektor.umcs.lublin.pl/~mikosmul/smoluchowski/=
+                 for a chronological table of Polish physicist
+                 Smoluchowski's life, and
+                 \url=http://en.wikipedia.org/wiki/Marian_Smoluchowski=
+                 for a biography. He worked on the kinetic theory of
+                 gases and Brownian motion at the same time as Einstein.
+                 He also explained the blue color of the sky as a result
+                 of light dispersion from atmospheric fluctuations.",
+  Schilpp-number = "105",
+}
+
+@Article{Einstein:1917:QSE,
+  author =       "Albert Einstein",
+  title =        "{Zum quantensatz von Sommerfeld und Epstein}.
+                 ({German}) [{On} the quantum theory of {Sommerfeld} and
+                 {Epstein}]",
+  journal =      j-VERH-DTSCH-PHYS-GES,
+  volume =       "19",
+  number =       "9--10",
+  pages =        "82--92",
+  day =          "30",
+  month =        may,
+  year =         "1917",
+  CODEN =        "VDPEAZ",
+  ISSN =         "0372-5448",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Deutsche Physikalische Gesellschaft, Verhandlungen",
+  journal-URL =  "http://catalog.hathitrust.org/Record/012306260",
+  language =     "German",
+  Schilpp-number = "103",
+  Whittaker-number = "81",
+}
+
+@Article{Einstein:1917:QSG,
+  author =       "Albert Einstein",
+  title =        "{Zur Quantentheorie der Strahlung}. ({German}) [{On}
+                 the {Quantum Theory of Radiation}]",
+  journal =      j-PHYSIKAL-Z,
+  volume =       "18",
+  number =       "??",
+  pages =        "121--128",
+  year =         "1917",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Republication of \cite{Einstein:1916:QSG}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "63b, 68",
+  language =     "German",
+  Schilpp-number = "106",
+  Whittaker-number = "82",
+}
+
+@Book{Einstein:1917:SAR,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber die spezielle und die allgemeine
+                 Relativit{\"a}tstheorie, gemeinverst{\"a}ndlich}.
+                 ({German}) [{On} the {Special and General Theory of
+                 Relativity}: a Popular Account]",
+  volume =       "38",
+  publisher =    pub-VIEWEG,
+  address =      pub-VIEWEG:adr,
+  pages =        "70",
+  year =         "1917",
+  LCCN =         "????",
+  bibdate =      "Wed Dec 14 07:02:34 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "66",
+  language =     "German",
+  remark =       "22nd edition 1988.",
+  Schilpp-number = "102",
+  Whittaker-number = "80",
+}
+
+@Article{Einstein:1918:BGN,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung zu Gehrckes Notiz: {\"U}ber den {\"A}ther}.
+                 ({German}) [{Remark} on {Gehrcke}'s Notes: {``On the
+                 Aether''}]",
+  journal =      j-VERH-DTSCH-PHYS-GES,
+  volume =       "20",
+  number =       "21--24",
+  pages =        "261--261",
+  day =          "30",
+  month =        dec,
+  year =         "1918",
+  CODEN =        "VDPEAZ",
+  ISSN =         "0372-5448",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "{Verhandlungen der Deutschen Physikalischen
+                 Gesellschaft}",
+  journal-URL =  "http://catalog.hathitrust.org/Record/012306260",
+  language =     "German",
+  Schilpp-number = "114",
+  Whittaker-number = "87",
+}
+
+@Article{Einstein:1918:BSN,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung zu Schr{\"o}dingers Notiz:
+                 L{\"o}sungssystem der allgemein Kovarienten
+                 Gravitationsgleichungen}. ({German}) [{Remark} on
+                 {Schr{\"o}dinger}'s note: Solution system of general
+                 covariant gravitation equations]",
+  journal =      j-PHYSIKAL-Z,
+  volume =       "19",
+  number =       "??",
+  pages =        "165--166",
+  year =         "1918",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "118",
+  Whittaker-number = "90",
+}
+
+@Article{Einstein:1918:DEG,
+  author =       "Albert Einstein",
+  title =        "{Dialog {\"u}ber Einw{\"a}nde gegen die
+                 Relativit{\"a}tstheorie}. ({German}) [{Dialogue} on
+                 objections to the {Theory of Relativity}]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "6",
+  number =       "??",
+  pages =        "697--702",
+  year =         "1918",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "74",
+  language =     "German",
+  Schilpp-number = "116",
+  Whittaker-number = "88",
+}
+
+@Article{Einstein:1918:EAR,
+  author =       "Albert Einstein",
+  title =        "{Der Energiesatz in der allgemeinen
+                 Relativit{\"a}tstheorie}. ({German}) [{The} {Law of
+                 Conservation of Energy} in the {General Theory of
+                 Relativity}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "??",
+  number =       "??",
+  pages =        "448--459",
+  year =         "1918",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "73",
+  language =     "German",
+  remark =       "Janssen \cite[page 59]{Janssen:2005:PHE} says of this
+                 paper ``[a gem] on the thorny issue of gravitational
+                 energy-momentum''.",
+  Schilpp-number = "121",
+  Whittaker-number = "93",
+}
+
+@Article{Einstein:1918:FAP,
+  author =       "Albert Einstein",
+  title =        "{Friedrich Adler als Physiker}. ({German}) [{Friedrich
+                 Adler} as a Physicist]",
+  journal =      "{Die Vossische Zeitung [Morgen Ausgabe]}",
+  volume =       "??",
+  number =       "259",
+  pages =        "2",
+  day =          "23",
+  month =        may,
+  year =         "1918",
+  bibdate =      "Mon Oct 30 09:10:19 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "109",
+}
+
+@Article{Einstein:1918:GGG,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber Gravitationswellen}. ({German}) [{On}
+                 Gravitational Waves]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "??",
+  number =       "??",
+  pages =        "154--167",
+  year =         "1918",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "70",
+  language =     "German",
+  remark =       "Janssen \cite[page 59]{Janssen:2005:PHE} says of this
+                 paper ``[a gem] on gravitational waves \ldots{}.''",
+  Schilpp-number = "119",
+  Whittaker-number = "91",
+}
+
+@Article{Einstein:1918:HWR,
+  author =       "Albert Einstein",
+  title =        "{H. Weyl: Raum, Zeit, Materie}. ({German}) [{Review}
+                 of {H. Weyl: {\em Space, Time, Matter}}]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "6",
+  number =       "??",
+  pages =        "373--373",
+  year =         "1918",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Mon Oct 30 09:39:15 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "115",
+}
+
+@Article{Einstein:1918:KHS,
+  author =       "Albert Einstein",
+  title =        "{Kritisches zu einer von Hrn. de Sitter gegebenen
+                 L{\"o}sung der Gravitationsgleichungen}. ({German})
+                 [{Critical} remarks on a solution of the gravitation
+                 equations given by {Mr. de Sitter}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "??",
+  number =       "??",
+  pages =        "270--272",
+  year =         "1918",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "120",
+  Whittaker-number = "92",
+}
+
+@Article{Einstein:1918:LSB,
+  author =       "Albert Einstein",
+  title =        "{Lassen sich Brechungsexponenten der K{\"o}rper
+                 f{\"u}r R{\"o}ntgenstrahlen experimentell ermitteln}.
+                 ({German}) [{Can} refraction exponents of the bodies
+                 for {X}-rays be determined experimentally?]",
+  journal =      j-VERH-DTSCH-PHYS-GES,
+  volume =       "20",
+  number =       "9--12",
+  pages =        "86--87",
+  day =          "30",
+  month =        jun,
+  year =         "1918",
+  CODEN =        "VDPEAZ",
+  ISSN =         "0372-5448",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "{Verhandlungen der Deutschen Physikalischen
+                 Gesellschaft}",
+  journal-URL =  "http://catalog.hathitrust.org/Record/012306260",
+  language =     "German",
+  Schilpp-number = "113",
+  Whittaker-number = "86",
+}
+
+@InProceedings{Einstein:1918:MFG,
+  author =       "A. Einstein",
+  booktitle =    "{Zu Max Plancks sechzigstem Geburtstag. Ansprachen,
+                 gehalten am 26. April 1918 in der Deutschen
+                 Physikalischen Gesellschaft}. ({German}) [{For} {Max
+                 Planck}'s sixtieth birthday. {Meeting} held on {26
+                 April 1918} in the {German Physical Society}]",
+  title =        "{Motive des Forschens}. ({German}) [{Principles} of
+                 research]",
+  publisher =    "C. F. M{\"u}ller",
+  address =      "Karlsruhe, Germany",
+  bookpages =    "36",
+  pages =        "29--32",
+  year =         "1918",
+  LCCN =         "????",
+  bibdate =      "Wed Dec 14 05:45:35 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in
+                 \cite[pp.~224--227]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "72",
+  language =     "German",
+  Schilpp-number = "111",
+}
+
+@Unpublished{Einstein:1918:NNA,
+  author =       "Albert Einstein",
+  title =        "On the Need for a {National Assembly}",
+  day =          "13",
+  month =        nov,
+  year =         "1918",
+  bibdate =      "Thu Jul 15 10:18:51 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Speech given to the pacifist organization Bund ``Neues
+                 Vaterland''. Published in \cite{Nathan:1960:EPa}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "75",
+  language =     "German",
+}
+
+@Article{Einstein:1918:NSA,
+  author =       "Albert Einstein",
+  title =        "{Notiz zu Schr{\"o}dingers Arbeit: Energiekomponenten
+                 des Gravitationsfelde}. ({German}) [{Note} on
+                 {Schr{\"o}dinger}'s work: {``Energy Components of
+                 Gravitation Fields''}]",
+  journal =      j-PHYSIKAL-Z,
+  volume =       "19",
+  number =       "??",
+  pages =        "115--116",
+  year =         "1918",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "117",
+  Whittaker-number = "89",
+}
+
+@Article{Einstein:1918:PAR,
+  author =       "Albert Einstein",
+  title =        "{Prinzipelles zur allgemeinen
+                 Relativit{\"a}tstheorie}. ({German}) [{Principles} of
+                 The {General Theory of Relativity}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "360",
+  number =       "4",
+  pages =        "241--244",
+  year =         "1918",
+  DOI =          "http://dx.doi.org/10.1002/andp.19183600402",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "71",
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  remark =       "According to Miller \cite[footnote on page
+                 88]{Miller:1999:EFS}, this is the paper in which
+                 Einstein first used the phrase {\"A}quivalenzprinzip
+                 (``Equivalence Principle'').",
+  Schilpp-number = "112",
+  Whittaker-number = "85",
+  xxvolume =     "55",
+}
+
+@Book{Einstein:1918:SAR,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber die spezielle und die allgemeine
+                 Relativit{\"a}tstheorie, gemeinverst{\"a}ndlich}.
+                 ({German}) [{On} the {Special and General Theory of
+                 Relativity} in Common Understanding]",
+  volume =       "38",
+  publisher =    pub-VIEWEG,
+  address =      pub-VIEWEG:adr,
+  edition =      "Third",
+  pages =        "83",
+  year =         "1918",
+  LCCN =         "????",
+  bibdate =      "Wed Dec 14 07:02:34 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "The third to ninth editions (1918--1920) have an
+                 appendix: ``Einfache Ableitung der
+                 Lorentz-transformation. Minkowskis vierdimensionale
+                 Welt'' (Simple derivativation of the Lorentz
+                 transformation. Minkowski's four-dimensional world).
+                 The 22nd edition appeared in 1988.",
+  Schilpp-number = "110",
+}
+
+@Unpublished{Einstein:1918:VAN,
+  author =       "Albert Einstein",
+  title =        "{An den Verein ``Allgemeine N{\"a}hrpflicht}.
+                 ({German}) [{To} the {Society ``A Guaranteed
+                 Subsistence for All''}]",
+  day =          "12",
+  month =        dec,
+  year =         "1918",
+  bibdate =      "Thu Jul 15 10:27:27 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Published in \cite[document 16]{Einstein:2002:CPA}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "76",
+  language =     "German",
+}
+
+@Book{Warburg:1918:MPS,
+  author =       "Emil Warburg and Max von Laue and Arnold Sommerfeld
+                 und Albert Einstein",
+  booktitle =    "{Zu Max Plancks sechzigstem Geburtstag: Ansprachen,
+                 gehalten am 26. April 1918 in der Deutschen
+                 Physikalischen Gesellschaft, nebst einer Erwiderung von
+                 M. Planck}",
+  title =        "{Zu Max Plancks sechzigstem Geburtstag: Ansprachen,
+                 gehalten am 26. April 1918 in der Deutschen
+                 Physikalischen Gesellschaft, nebst einer Erwiderung von
+                 M. Planck}",
+  publisher =    "C. F. M{\"u}llerschen Hofbuchhandlung m.b.H.",
+  address =      "Karlsruhe, Germany",
+  pages =        "36",
+  year =         "1918",
+  DOI =          "http://dx.doi.org/10.1002/bbpc.19180242310",
+  ISSN =         "0005-9021",
+  bibdate =      "Fri Sep 18 08:55:29 2015",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/p/planck-max.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1919:BPSa,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung {\"u}ber periodische Schwankungen der
+                 Mondl{\"a}nge, welche bisher nach der Newtonschen
+                 Mechanik nicht erkl{\"a}rbar schienen}. ({German})
+                 [{Comments} on periodic fluctuations of the {Moon}'s
+                 longitude, which so far appeared to be inexplicable in
+                 {Newtonian} mechanics]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "??",
+  number =       "??",
+  pages =        "433--436",
+  day =          "24",
+  month =        apr,
+  year =         "1919",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "78",
+  language =     "German",
+  Schilpp-number = "124a",
+  Whittaker-number = "96a",
+}
+
+@Article{Einstein:1919:BPSb,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung {\"u}ber periodische Schwankungen der
+                 Mondl{\"a}nge, welche bisher nach der Newtonschen
+                 Mechanik nicht erkl{\"a}rbar schienen}. ({German})
+                 [{Remark} on periodic fluctuations of the {Moon}'s
+                 distance, which did not seem explainable so far after
+                 {Newton}'s mechanics]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-2,
+  volume =       "??",
+  number =       "??",
+  pages =        "711--711",
+  year =         "1919",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See \cite{vonBrunn:1919:HEB}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "124b",
+  Whittaker-number = "96b",
+}
+
+@Article{Einstein:1919:FAR,
+  author =       "Albert Einstein",
+  title =        "{Feldgleichungen der allgemeinen
+                 Relativit{\"a}tstheorie vom Standpunkte des
+                 kosmologischen Problems und des problems der
+                 Konstitution der Materie }. ({German}) [{Field}
+                 equation of the {Theory of General Relativity} from the
+                 point of view of the cosmological problem and the
+                 problem of the constitution of matter]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "26",
+  number =       "??",
+  pages =        "463--463",
+  day =          "15",
+  month =        may,
+  year =         "1919",
+  bibdate =      "Mon Oct 30 09:41:29 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Title only. Essentially the paper
+                 \cite{Einstein:1919:SGI}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "125",
+}
+
+@Article{Einstein:1919:IDP,
+  author =       "Albert Einstein",
+  title =        "Induction and Deduction in Physics",
+  journal =      "{Berliner Tageblatt}",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "25",
+  month =        dec,
+  year =         "1919",
+  bibdate =      "Sat Feb 09 09:58:15 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted, with commentary, in
+                 \cite{Kostro:1998:AEH}.",
+  acknowledgement = ack-nhfb,
+  xxnote =       "Find original German title",
+}
+
+@Article{Einstein:1919:IUD,
+  author =       "Albert Einstein",
+  title =        "{Induktion unde Deduktion der Physik}. ({German})
+                 [{Induction} and Deduction in Physics]",
+  journal =      "Berliner Tageblatt",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "25",
+  month =        dec,
+  year =         "1919",
+  bibdate =      "Thu Jul 15 10:38:22 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Section 4.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "81",
+  language =     "German",
+}
+
+@Article{Einstein:1919:LAP,
+  author =       "Albert Einstein",
+  title =        "{Leo Arons als Physiker}. ({German}) [{Leo Arons} as
+                 Physicist]",
+  journal =      "Sozialistische Monatshefte (Jarhgang 52, part 2)",
+  volume =       "??",
+  number =       "??",
+  pages =        "1055--1056",
+  year =         "1919",
+  bibdate =      "Mon Oct 30 09:46:04 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "83",
+  language =     "German",
+  remark =       "Obituary for Leo Arons.",
+  Schilpp-number = "127",
+}
+
+@Article{Einstein:1919:PAR,
+  author =       "Albert Einstein",
+  title =        "{Pr{\"u}fung der allgemeinen Relativit{\"a}tstheorie}.
+                 ({German}) [{A} Test of the {General Theory of
+                 Relativity}]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "7",
+  number =       "??",
+  pages =        "776--776",
+  year =         "1919",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "79",
+  language =     "German",
+  Schilpp-number = "122",
+  Whittaker-number = "94",
+}
+
+@Article{Einstein:1919:SGI,
+  author =       "Albert Einstein",
+  title =        "{Spielen die Gravitationsfelder im Aufbau der
+                 materiellen Elementarteilchen eine wesentliche Rolle?}.
+                 ({German}) [{Do} gravitational fields play a
+                 substantial role in the structure of the elementary
+                 particles of matter?]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "20",
+  number =       "??",
+  pages =        "349--356",
+  day =          "10",
+  month =        apr,
+  year =         "1919",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "77",
+  language =     "German",
+  Schilpp-number = "123",
+  Whittaker-number = "95",
+}
+
+@Article{Einstein:1919:TSG,
+  author =       "A. Einstein",
+  title =        "Time, Space, and Gravitation",
+  journal =      "{The Times (London)}",
+  volume =       "??",
+  number =       "??",
+  pages =        "13--14",
+  day =          "28",
+  month =        nov,
+  year =         "1919",
+  bibdate =      "Wed Dec 14 05:43:28 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted as ``What is the Theory of Relativity?'' In
+                 \cite[227--232]{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "80",
+  remark =       "This essay thanks England and English scientists for
+                 their efforts in testing the General Theory of
+                 Relativity in the 1919 solar eclipse experiments.",
+  Schilpp-number = "126",
+  Whittaker-number = "97",
+  xxtitle =      "My Theory (in \cite{Whittaker:1955:AE})",
+}
+
+@Article{Einstein:1919:WRG,
+  author =       "Albert Einstein",
+  title =        "{Was ist Relativit{\"a}tstheorie?} ({German}) [{What}
+                 is the Theory of Relativity?]",
+  journal =      "????",
+  volume =       "??",
+  number =       "??",
+  pages =        "??",
+  year =         "1919",
+  bibdate =      "Wed Dec 14 06:41:05 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite[pp.~209ff]{Seelig:1991:AEM}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "This may be the German translation of
+                 \cite{Einstein:1919:TSG} given in
+                 \cite{Einstein:1934:MW}. Schilpp
+                 \cite{Schilpp:1949:AEPa} gives title ``My Theory'' for
+                 \cite{Einstein:1919:TSG}, but copied under title
+                 ``Time, Space, and Gravitation'' in {\em Optician, The
+                 British Optical Journal} {\bf 58}, pp.\ 187--188, and
+                 noted with quotations in {\em Nature} {\bf 104}, p.
+                 360. Reprinted in {\em Living Age} {\bf 304}, pp.
+                 41--43.",
+  xxnote =       "Find journal information??",
+}
+
+@Article{Einstein:1919:ZOG,
+  author =       "Albert Einstein",
+  title =        "{Die Zuwanderung aus dem Osten}. ({German})
+                 [{Immigration} from the {East}]",
+  journal =      "Berliner Tageblatt",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "30",
+  month =        dec,
+  year =         "1919",
+  bibdate =      "Thu Jul 15 10:38:22 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Morning edition.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "82",
+  language =     "German",
+  remark =       "Letter in opposition to the view that Jews from
+                 Eastern Europe were responsible for Germany's post-war
+                 problems.",
+}
+
+@Book{Einstein:1920:ARG,
+  author =       "Albert Einstein",
+  title =        "{{\"A}ther und Relativit{\"a}tstheorie}. ({German})
+                 [{Ether} and The {Theory of Relativity}]",
+  publisher =    pub-SV,
+  address =      pub-SV:adr,
+  pages =        "????",
+  year =         "1920",
+  bibdate =      "Thu Jul 15 10:49:19 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Einstein's lecture at the University of Leiden after
+                 his appointment as Visiting Professor.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "86",
+  language =     "German",
+}
+
+@Book{Einstein:1920:ART,
+  author =       "Albert Einstein",
+  title =        "{{\"A}ther und die Relativit{\"a}ts-Theorie: Rede
+                 Gehalten am 5. Mai 1920 an der Reichs-Universit{\"a}t
+                 zu Leiden}. ({German}) [{Aether} and the {Theory of
+                 Relativity}. Speech Held on 5 May 1920 at the State
+                 University of Leiden]",
+  publisher =    pub-SV,
+  address =      pub-SV:adr,
+  pages =        "15",
+  year =         "1920",
+  bibdate =      "Wed Sep 28 06:09:25 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "An address delivered on May 5th, 1920, in the
+                 University of Leyden. English translation in
+                 \cite{Einstein:1922:SRE,Einstein:1983:SR}. French
+                 translation in \cite{Einstein:1921:LTR} and Italian
+                 translation in \cite{Einstein:1922:PRD}.",
+  URL =          "http://www.mountainman.com.au/aether_0.html",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "131",
+}
+
+@Article{Einstein:1920:BAW,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung zur Abhandlung von W. R. Hess: Theorie der
+                 Viscosit{\"a}t heterogener Systeme}. ({German})
+                 [{Remark} on the paper on {W. R. Hess}: {``Theory of
+                 the viscosity of heterogeneous systems''}]",
+  journal =      "Kolloidzschr",
+  volume =       "27",
+  number =       "??",
+  pages =        "137--137",
+  year =         "1920",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "132",
+  Whittaker-number = "98",
+}
+
+@Article{Einstein:1920:C,
+  author =       "Albert Einstein",
+  title =        "A Confession",
+  journal =      "Israelistisches Wochenblatt f{\"u}r die Schweiz",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "24",
+  month =        sep,
+  year =         "1920",
+  bibdate =      "Thu Jul 15 10:46:43 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Comments on anti-Semitism",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "85",
+  language =     "German",
+}
+
+@InCollection{Einstein:1920:CII,
+  author =       "Albert Einstein",
+  booktitle =    "Thoughts on Reconciliation",
+  title =        "On the Contribution of Intellectuals to International
+                 Reconciliation",
+  publisher =    "Deutscher Gesellig-Wissenschaftlicher Verein von New
+                 York",
+  address =      "New York, NY, USA",
+  bookpages =    "47 + 1",
+  pages =        "??--??",
+  year =         "1920",
+  LCCN =         "D645 .D4 FT MEADE",
+  bibdate =      "Thu Jul 15 10:57:38 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Invited and compiled by the Social and scientific
+                 society of New York, in commemoration of the fiftieth
+                 anniversary of its foundation. 1870--1920.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "91",
+}
+
+@Book{Einstein:1920:EBK,
+  author =       "Albert Einstein",
+  title =        "{Zur elektrodynamic bewegter korper}. ({German}) [{On}
+                 the electrodynamics of moving bodies]",
+  publisher =    pub-TEUBNER,
+  address =      pub-TEUBNER:adr,
+  pages =        "26--50",
+  year =         "1920",
+  LCCN =         "????",
+  bibdate =      "Wed Nov 14 16:18:15 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1920:GAP,
+  author =       "Albert Einstein",
+  title =        "To the {``General Assembly for Popular Technical
+                 Education''}",
+  journal =      "Neue Freie Presse",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "24",
+  month =        jul,
+  year =         "1920",
+  bibdate =      "Thu Jul 15 10:51:47 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "88",
+  language =     "German",
+}
+
+@Article{Einstein:1920:IIC,
+  author =       "Albert Einstein",
+  title =        "Interview on Interplanetary Communication",
+  journal =      "Daily Mail (London)",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "31",
+  month =        jan,
+  year =         "1920",
+  bibdate =      "Thu Jul 15 11:01:13 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Quoted in New York Times, February 2, 1920.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "92",
+}
+
+@Article{Einstein:1920:ILS,
+  author =       "Albert Einstein",
+  title =        "{Inwiefern l{\"a}sst sich die moderne
+                 Gravitationstheorie ohne die Relativit{\"a}t
+                 begrunden}. ({German}) [{In} what respect can the
+                 modern {Theory of Gravitation} be established without
+                 {Relativity}?]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "8",
+  number =       "??",
+  pages =        "1010--1011",
+  year =         "1920",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "133",
+  Whittaker-number = "99",
+}
+
+@Article{Einstein:1920:MAA,
+  author =       "Albert Einstein",
+  title =        "{Meine Antwort {\"u}ber die
+                 antirelativit{\"a}tstheoretische G.m.b.H. (Gesellschaft
+                 mit beschr{\"a}nkter Haftung)}. ({German}) [{My} answer
+                 to {Antirelativity Theoretical Co. Ltd.}]",
+  journal =      "Berliner Tageblatt und Handelszeitung",
+  volume =       "??",
+  number =       "??",
+  pages =        "1--2",
+  day =          "17",
+  month =        aug,
+  year =         "1920",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "90",
+  language =     "German",
+  Schilpp-number = "136",
+  Whittaker-number = "101",
+  xxday =        "27",
+}
+
+@Article{Einstein:1920:NSE,
+  author =       "Albert Einstein",
+  title =        "On New Sources of Energy",
+  journal =      "Berliner Tageblatt",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "25",
+  month =        jul,
+  year =         "1920",
+  bibdate =      "Thu Jul 15 10:53:00 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Morning edition. Comment on possible use of atomic
+                 energy.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Book{Einstein:1920:PRO,
+  author =       "Albert Einstein and H. (Hermann) Minkowski",
+  title =        "The {Principle of Relativity}: original papers",
+  publisher =    "The University of Calcutta",
+  address =      "Calcutta, India",
+  pages =        "3 + xxiii + 186",
+  year =         "1920",
+  LCCN =         "QC6 .E45",
+  bibdate =      "Mon Oct 9 07:52:59 MDT 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  note =         "Translated by Meghnad N. Saha (1893--1956) and
+                 Satyendranath N. Bose (1894--1974). with a historical
+                 introduction, by P. C. Mahalanobis.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955, 1864--1909",
+  Schilpp-number = "128",
+  subject =      "Relativity (physics)",
+}
+
+@Book{Einstein:1920:RSG,
+  author =       "Albert Einstein",
+  title =        "{Relativity, the Special and the General Theory}: a
+                 Popular Exposition",
+  publisher =    pub-METHUEN,
+  address =      pub-METHUEN:adr,
+  pages =        "xiii + 138",
+  year =         "1920",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 09:52:29 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Authorized translation by Robert W. Lawson from the
+                 fifth German edition \cite{Einstein:1918:SAR}.",
+  URL =          "http://www.gsjournal.net/Science-Journals/Essays/View/2494",
+  acknowledgement = ack-nhfb,
+  Schilpp-number = "130",
+}
+
+@Book{Einstein:1920:SAR,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber die spezielle und die allgemeine
+                 Relativit{\"a}tstheorie, gemeinverst{\"a}ndlich}.
+                 ({German}) [{On} the {Special and General Theory of
+                 Relativity} in Common Understanding]",
+  publisher =    pub-VIEWEG,
+  address =      pub-VIEWEG:adr,
+  edition =      "Tenth",
+  pages =        "91",
+  year =         "1920",
+  LCCN =         "????",
+  bibdate =      "Wed Dec 14 07:02:34 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "The 22nd edition appeared in 1988.",
+  Schilpp-number = "129",
+}
+
+@Article{Einstein:1920:STD,
+  author =       "Albert Einstein",
+  title =        "{Schallausbreitung in teilweise dissoziierten Gasen}.
+                 ({German}) [{Sound} propagation in partly dissociated
+                 gases]",
+  journal =      "S. B. brews. Akad. Wzk.",
+  volume =       "??",
+  number =       "??",
+  pages =        "380--385",
+  year =         "1920",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "87",
+  language =     "German",
+  Schilpp-number = "135",
+  Whittaker-number = "100",
+}
+
+@Article{Einstein:1920:TWG,
+  author =       "Albert Einstein",
+  title =        "{Tragheitsmoment des Wasserstoffmolekuls}. ({German})
+                 [{Moment} of inertia of the hydrogen molecule]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "??",
+  number =       "??",
+  pages =        "65--65",
+  year =         "1920",
+  bibdate =      "Mon Oct 30 09:56:29 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "134",
+  xxnote =       "Check journal: which part of Sitzungsberichte??",
+}
+
+@Article{Einstein:1920:ULH,
+  author =       "Albert Einstein",
+  title =        "Uproar in the Lecture Hall",
+  journal =      "8-Uhr Abendblatt",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "13",
+  month =        feb,
+  year =         "1920",
+  bibdate =      "Thu Jul 15 10:44:06 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "News story of Einstein lecture being heckled by
+                 anti-Semitic ``students''.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "84",
+  language =     "German",
+}
+
+@Article{Einstein:1921:AGM,
+  author =       "Albert Einstein",
+  title =        "{Zur Abwehr}. ({German}) [{In} my Defense]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "9",
+  number =       "??",
+  pages =        "261--264",
+  year =         "1921",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Thu Jul 15 11:12:32 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "97",
+  language =     "German",
+}
+
+@Article{Einstein:1921:BOD,
+  author =       "Albert Einstein",
+  title =        "A brief outline of the development of the {Theory of
+                 Relativity}",
+  journal =      j-NATURE,
+  volume =       "106",
+  number =       "2677",
+  pages =        "782--784",
+  day =          "17",
+  month =        feb,
+  year =         "1921",
+  CODEN =        "NATUAS",
+  ISSN =         "0028-0836 (print), 1476-4687 (electronic)",
+  ISSN-L =       "0028-0836",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated by Robert W. Lawson from the German
+                 manuscript. Special issue on Relativity. This is one of
+                 only three papers by foreign authors in this issue; the
+                 others are \cite{Lorentz:1921:MME,Weyl:1921:EG}.",
+  URL =          "http://www.nature.com/nature/journal/v106/n2677/pdf/106782a0.pdf;
+                 http://www.nature.com/physics/looking-back/einstein/einstein.pdf",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "96",
+  journal-URL =  "http://www.nature.com/nature/archive/",
+  Schilpp-number = "147",
+  Whittaker-number = "104",
+}
+
+@Article{Einstein:1921:DWG,
+  author =       "Albert Einstein",
+  title =        "{Die Not der deutschen Wissenschaft. Ein Gefahr
+                 f{\"u}r die Nation}. ({German}) [{The} Plight of
+                 {German} Science: a Danger for the Nation]",
+  journal =      "Neue Freie Presse",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "25",
+  month =        dec,
+  year =         "1921",
+  bibdate =      "Thu Jul 15 11:32:57 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "105",
+  language =     "German",
+}
+
+@Article{Einstein:1921:EAE,
+  author =       "Albert Einstein",
+  title =        "{Einsteins amerikanische Eindr{\"u}cke. Was er
+                 wirklich sah}. ({German}) [{Einstein}'s Impressions of
+                 {America}: What He Really Saw]",
+  journal =      "{Die Vossische Zeitung [Morgen Ausgabe]}",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "10",
+  month =        jul,
+  year =         "1921",
+  bibdate =      "Thu Jul 15 11:27:03 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Partial quotation, and English translation, in
+                 \cite{Sopka:1988:QPA}",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "102",
+  language =     "German",
+}
+
+@Article{Einstein:1921:EAN,
+  author =       "Albert Einstein",
+  title =        "{Eine Einfache Anwendung des Newtonschen
+                 Gravitationsgesetzes auf die Kugelf{\"o}rmigen
+                 Sternhaufen}. ({German}) [{A} Simple Application of the
+                 {Newtonian Law of Gravitation} to Globular Star
+                 Clusters]",
+  journal =      "Kaiser Wilhelm Gesellschaft z{\"u}r Forderung der
+                 Wissenchaft, Festschrift",
+  volume =       "??",
+  number =       "??",
+  publisher =    pub-SV,
+  address =      pub-SV:adr,
+  pages =        "50--52",
+  year =         "1921",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in
+                 \cite[pp.~420--425]{Janssen:2002:CPAa}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "99",
+  language =     "German",
+  Schilpp-number = "146",
+  Whittaker-number = "103",
+}
+
+@Article{Einstein:1921:EE,
+  author =       "Albert Einstein",
+  title =        "{Einstein} on Education",
+  journal =      "Nation and Athenaeum",
+  volume =       "30",
+  number =       "??",
+  pages =        "378--379",
+  year =         "1921",
+  bibdate =      "Thu Jul 15 11:02:49 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "93",
+}
+
+@Article{Einstein:1921:EHU,
+  author =       "Albert Einstein",
+  title =        "{Zur Errichtung der hebr{\"a}ischen Universit{\"a}t in
+                 Jerusalem}. ({German}) [{On} the Founding of the
+                 {Hebrew University of Jerusalem}]",
+  journal =      "J{\"u}dische Pressezentrale Z{\"u}rich",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "26",
+  month =        aug,
+  year =         "1921",
+  bibdate =      "Thu Jul 15 11:29:53 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "103",
+  language =     "German",
+}
+
+@Article{Einstein:1921:ELB,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber ein den Elementarprozess der Lichtemission
+                 betreffendes Experiment}. ({German}) [{On} an
+                 experiment concerning the elementary process of light
+                 emission]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-2,
+  volume =       "??",
+  number =       "??",
+  pages =        "882--883",
+  year =         "1921",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "104",
+  language =     "German",
+  Schilpp-number = "150",
+  Whittaker-number = "107",
+}
+
+@Book{Einstein:1921:GEE,
+  author =       "Albert Einstein",
+  title =        "{Geometrie und Erfahrung: Erweiterte Fassung des
+                 Festvortrages gehalten an der preussischen Akademie}.
+                 ({German}) [{Geometry} and Experience: {Extended}
+                 version of the commemorative address held at the
+                 {Prussian Academy}]",
+  publisher =    pub-SV,
+  address =      pub-SV:adr,
+  pages =        "20",
+  year =         "1921",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 10:30:52 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "95",
+  language =     "German",
+  remark =       "English translation in \cite{Einstein:1922:SRE},
+                 \cite[pp.~232--246]{Einstein:1982:IO}, and
+                 \cite[pp.~421--432]{Einstein:2002:CPA}. French
+                 translation in \cite{Einstein:1921:GEF}. Italian
+                 translation in \cite{Einstein:1922:PRD}. Russian
+                 translation in \cite{Einstein:1922:FPP}. Contains on
+                 second page the oft-repeated quote ``As far as the laws
+                 of mathematics refer to reality, they are not certain;
+                 and as far as they are certain, they do not refer to
+                 reality.''",
+  Schilpp-number = "143",
+}
+
+@InProceedings{Einstein:1921:GEG,
+  author =       "A. Einstein",
+  booktitle =    "{Erweiterte Fassung des Festvortrages gehalten an der
+                 Preussischen Akademie der Wissenschaften zu Belin am
+                 27. Januar 1921}",
+  title =        "{Geometrie und Erfahrung}. ({German}) [{Geometry} and
+                 Experience]",
+  publisher =    pub-JULIUS-SPRINGER,
+  address =      pub-JULIUS-SPRINGER:adr,
+  pages =        "123--130",
+  year =         "1921",
+  LCCN =         "????",
+  bibdate =      "Wed Dec 14 05:49:24 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in
+                 \cite[232--246]{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "148",
+  Whittaker-number = "105",
+}
+
+@Article{Einstein:1921:GKW,
+  author =       "Albert Einstein",
+  title =        "{Das Gemeinsame am k{\"u}nstlerischen und
+                 wissenschaftlichen Erleben}. ({German}) [{The} Common
+                 Element in Scientific and Artistic Experience]",
+  journal =      "Menschen. Zeitschrift neuer Kunst",
+  volume =       "4",
+  number =       "??",
+  pages =        "19--19",
+  year =         "1921",
+  bibdate =      "Thu Jul 15 11:04:23 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "94",
+  language =     "German",
+}
+
+@Book{Einstein:1921:GLF,
+  author =       "Albert Einstein",
+  title =        "La {G}{\'e}om{\'e}trie et {L}'exp{\'e}rience.
+                 ({French}) [{Geometry} and Experience]",
+  publisher =    pub-GAUTHIER-VILLARS,
+  address =      pub-GAUTHIER-VILLARS:adr,
+  pages =        "20",
+  year =         "1921",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 10:34:33 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "French translation by Maurice Solovine of
+                 \cite{Einstein:1921:GEE}.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+  Schilpp-number = "144",
+}
+
+@Article{Einstein:1921:JP,
+  author =       "Albert Einstein",
+  title =        "On a {Jewish Palestine}",
+  journal =      "J{\"u}dische Rundschau",
+  volume =       "??",
+  number =       "??",
+  pages =        "371--371",
+  day =          "1",
+  month =        jul,
+  year =         "1921",
+  bibdate =      "Thu Jul 15 11:20:06 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "101",
+  language =     "German",
+}
+
+@Book{Einstein:1921:LTR,
+  author =       "Albert Einstein",
+  title =        "{L}'{\'e}ther et la Th{\'e}orie de Relativit{\'e}.
+                 ({French}) [{Aether} and the Theory of Relativity]",
+  publisher =    pub-GAUTHIER,
+  address =      pub-GAUTHIER:adr,
+  pages =        "15",
+  year =         "1921",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 10:36:46 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "French translation by Maurice Solovine of
+                 \cite{Einstein:1920:ART}.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+  Schilpp-number = "145",
+}
+
+@Book{Einstein:1921:MRF,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}: four lectures delivered
+                 at {Princeton University, May, 1921}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "v + 123",
+  year =         "1921",
+  LCCN =         "QC6",
+  bibdate =      "Wed Nov 23 13:15:51 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in 1922 and 1923 by the same publisher, and
+                 by Methuen (London) in 1922 and 1924.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "109b",
+  remark =       "Translation to English by Edwin Plimpton Adams.",
+  Schilpp-number = "142",
+}
+
+@Article{Einstein:1921:NEF,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber eine naheliegende Erg{\"a}nzung des
+                 Fundamentes der allgemeinen Relativit{\"a}tstheorie}.
+                 ({German}) [{A} natural addition to the foundation of
+                 the {General Theory of Relativity}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-1,
+  volume =       "??",
+  number =       "??",
+  pages =        "261--264",
+  year =         "1921",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "97",
+  language =     "German",
+  Schilpp-number = "149",
+  Whittaker-number = "106",
+}
+
+@Article{Einstein:1921:RLK,
+  author =       "Albert Einstein",
+  title =        "Report of lecture at {King's College} on the
+                 development and present position of {Relativity}, with
+                 quotations",
+  journal =      "Nation and Athenaeum",
+  volume =       "29",
+  number =       "??",
+  pages =        "431--432",
+  year =         "1921",
+  bibdate =      "Mon Oct 30 10:52:00 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  remark =       "The German text is included in
+                 \cite{Einstein:1934:MW}, and an English translation in
+                 \cite{Einstein:1934:WSI} and
+                 \cite[pp.~246--249]{Einstein:1982:IO}.",
+  Schilpp-number = "151",
+  xxnote =       "What language was this printed in??",
+}
+
+@Book{Einstein:1921:RSG,
+  author =       "Albert Einstein",
+  title =        "{Relativity, the Special and the General Theory}: a
+                 Popular Exposition",
+  publisher =    "Holt",
+  address =      "New York, NY, USA",
+  pages =        "xiii + 168",
+  year =         "1921",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 10:00:18 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "This differs from the English edition
+                 \cite{Einstein:1920:RSG} only in pagination. Reprinted
+                 in 1931 (Smith, New York) and in 1947 (Hartsdale House,
+                 Inc., New York).",
+  acknowledgement = ack-nhfb,
+  Schilpp-number = "137",
+}
+
+@Book{Einstein:1921:STS,
+  author =       "Albert Einstein",
+  title =        "{Sulla Teoria Speciale e Generale della
+                 Relativit{\`a}: Volgarizzazione}. ({Italian}) [On the
+                 {Special and General Theory of Relativity}: Popular
+                 Edition]",
+  publisher =    "Zanichelli",
+  address =      "Bologna, Italy",
+  pages =        "xii + 125",
+  year =         "1921",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 10:06:17 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Italian translation G. L. Calisse of
+                 \cite{Einstein:1920:SAR}.",
+  acknowledgement = ack-nhfb,
+  language =     "Italian",
+  Schilpp-number = "139",
+  xxnote =       "Check title translation??",
+}
+
+@Book{Einstein:1921:TOO,
+  author =       "Albert Einstein",
+  title =        "Teoriaa Otnositel'nosti: Obshchedostypnoe Izloshenie.
+                 ({Russian}) [{On} the {Special and General Theory of
+                 Relativity} in Common Understanding]",
+  publisher =    "Slowo",
+  address =      "Berlin, Germany",
+  pages =        "150",
+  year =         "1921",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 10:10:35 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Russian translation by G. B. Itel'son of
+                 \cite{Einstein:1920:SAR}.",
+  acknowledgement = ack-nhfb,
+  language =     "Russian",
+  Schilpp-number = "140",
+  xxnote =       "Check title translation??",
+}
+
+@Book{Einstein:1921:TRE,
+  author =       "Albert Einstein",
+  title =        "Teoria de la Relatividad Especial y General.
+                 ({Spanish}) [{Theory} of {Special and General
+                 Relativity}]",
+  publisher =    "Pel{\'a}ez",
+  address =      "Toledo, Spain",
+  pages =        "79",
+  year =         "1921",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 10:03:12 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translation to Spanish of the 12th edition by F.
+                 Lorente.",
+  acknowledgement = ack-nhfb,
+  language =     "Spanish",
+  remark =       "Reprinted in 1923 (Ruize de Lara, Cuenca) and 1925
+                 (Medina, Toledo).",
+  Schilpp-number = "138",
+}
+
+@Book{Einstein:1921:TRR,
+  author =       "Albert Einstein",
+  title =        "{La Th{\'e}orie de la Relativit{\'e} Restreinte de
+                 G{\'e}n{\'e}ralis{\'e}e}. ({French}) [{The Special and
+                 General Theory of Relativity}]",
+  publisher =    pub-GAUTHIER,
+  address =      pub-GAUTHIER:adr,
+  pages =        "xii + 120",
+  year =         "1921",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 10:21:56 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "French translation by Mlle. J. Rouviere of the tenth
+                 German edition \cite{Einstein:1920:SAR}.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+  Schilpp-number = "141",
+}
+
+@Article{Einstein:1921:WIZ,
+  author =       "Albert Einstein",
+  title =        "{Wie ich Zionist Wurde}. ({German}) [{How} {I} became
+                 a {Zionist}]",
+  journal =      "J{\"u}dische Rundschau",
+  volume =       "??",
+  number =       "??",
+  pages =        "351--352",
+  day =          "21",
+  month =        jun,
+  year =         "1921",
+  bibdate =      "Thu Jul 15 11:18:42 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "100",
+  language =     "German",
+}
+
+@Article{Einstein:1922:BAF,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung zu der Arbeit von A. Friedmann: {\"U}ber
+                 die Kr{\"u}mmung des R{\"a}umes}. ({German}) [{Remarks}
+                 on the work of {A. Friedmann}: {{\em On the Curvature
+                 of Space}}]",
+  journal =      j-Z-PHYSIK,
+  volume =       "11",
+  number =       "??",
+  pages =        "326--326",
+  year =         "1922",
+  CODEN =        "ZEPYAA",
+  ISSN =         "0044-3328",
+  bibdate =      "Mon Oct 30 11:04:28 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in \cite{Einstein:1986:CWF}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "165",
+}
+
+@Article{Einstein:1922:BAT,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung zu der Abhandlung von E. Trefftz: Statische
+                 Gravitationsfeld zweien Massenpunkte}. ({German})
+                 [{Remark} on the paper by {E. Trefftz}: {``Static
+                 gravitational field of two point masses''}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "448--449",
+  year =         "1922",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "163",
+  Whittaker-number = "111",
+}
+
+@Article{Einstein:1922:BSA,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung zu der Seletyschen Arbeit: Beitr{\"a}ge zum
+                 Kosmologischen System}. ({German}) [{Remark} on the
+                 {Selety} work: {``Contributions to the cosmological
+                 system''}]",
+  journal =      j-ANN-PHYS-1900-4,
+  volume =       "374",
+  number =       "22",
+  pages =        "436--438",
+  year =         "1922",
+  DOI =          "http://dx.doi.org/10.1002/andp.19223742203",
+  ISSN =         "0003-3804",
+  ISSN-L =       "0003-3804",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annalen der Physik (1900) (series 4)",
+  language =     "German",
+  Schilpp-number = "159",
+  Whittaker-number = "109",
+  xxvolume =     "69",
+}
+
+@Article{Einstein:1922:CG,
+  author =       "Albert Einstein",
+  title =        "Conditions in {Germany}",
+  journal =      j-NEW-REPUBLIC,
+  volume =       "32",
+  number =       "??",
+  pages =        "197--197",
+  year =         "1922",
+  ISSN =         "0028-6583",
+  bibdate =      "Fri Jul 16 07:17:25 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "106",
+}
+
+@Article{Einstein:1922:EBG,
+  author =       "Albert Einstein",
+  title =        "{Experiment betreffend die G{\"u}tigkeitsgrenze der
+                 Undulationstheorie}. ({German}) [{Experiment}
+                 Concerning the Limits of Validity of the Wave Theory]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "4--4",
+  year =         "1922",
+  bibdate =      "Fri Jul 16 09:16:31 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "111",
+  fjournal =     "K{\"o}niglich Preussische Akademie der Wissenschaften
+                 (Berlin)",
+  language =     "German",
+}
+
+@Article{Einstein:1922:EWF,
+  author =       "Albert Einstein",
+  title =        "{Emil Warburg als Forscher}. ({German}) [{Emil
+                 Warburg} as a Researcher]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "10",
+  number =       "??",
+  pages =        "823--828",
+  year =         "1922",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Mon Oct 30 11:02:04 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "161",
+  subject-dates = "March 9, 1846 -- July 28, 1931",
+}
+
+@Book{Einstein:1922:FPP,
+  author =       "Albert Einstein",
+  title =        "{O Fizicheskoi Prirodie Prostranstva}. ({Russian})
+                 [{Physical} Nature of Space]",
+  publisher =    "Slowo",
+  address =      "Berlin, Germany",
+  pages =        "52",
+  year =         "1922",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 10:46:34 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Russian translation of
+                 \cite{Einstein:1920:ART,Einstein:1921:GEE}.",
+  acknowledgement = ack-nhfb,
+  language =     "Russian",
+  Schilpp-number = "155",
+}
+
+@InCollection{Einstein:1922:ISD,
+  author =       "Albert Einstein",
+  booktitle =    "{Die Friedensbewegung}. ({German}) [{The} Peace
+                 Movement]",
+  title =        "Impact of Science on the Development of Pacifism",
+  publisher =    "Schwetschke",
+  address =      "Berlin, Germany",
+  pages =        "78--79",
+  year =         "1922",
+  bibdate =      "Fri Jul 16 07:21:01 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "108",
+  language =     "German",
+}
+
+@Book{Einstein:1922:KAR,
+  author =       "Albert Einstein",
+  title =        "{A K{\"u}l{\"o}nleges es az {\'A}ltal{\'a}nos
+                 Relativit{\'a}s, Elm{\'e}lette}. ({Hungarian}) [{On}
+                 the {Special and General Theory of Relativity} in
+                 Common Understanding]",
+  publisher =    "Pantheon irodalmi",
+  address =      "Budapest, Hungary",
+  pages =        "94",
+  year =         "1922",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 10:43:44 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Hungarian translation of \cite{Einstein:1920:SAR}.",
+  acknowledgement = ack-nhfb,
+  language =     "Hungarian",
+  Schilpp-number = "154",
+}
+
+@Book{Einstein:1922:MRF,
+  author =       "Albert Einstein and Edwin P. (Edwin Plimpton) Adams",
+  title =        "The Meaning of {Relativity}: four lectures delivered
+                 at {Princeton University, May, 1921}",
+  publisher =    pub-METHUEN,
+  address =      pub-METHUEN:adr,
+  pages =        "v + 123",
+  year =         "1922",
+  LCCN =         "QC6",
+  bibdate =      "Wed Nov 23 13:15:51 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  remark =       "The translation of these lectures into English was
+                 made by Edwin Plimpton Adams.",
+  Whittaker-number = "102",
+}
+
+@Article{Einstein:1922:MWR,
+  author =       "Albert Einstein",
+  title =        "In Memorium {Walther Rathenau}",
+  journal =      "Neue Rundschau",
+  volume =       "33 (part 2)",
+  number =       "??",
+  pages =        "815--816",
+  year =         "1922",
+  bibdate =      "Fri Jul 16 07:18:29 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "107",
+  language =     "German",
+  remark =       "Eulogy for the assassinated German foreign minister.",
+}
+
+@Book{Einstein:1922:PRD,
+  author =       "Albert Einstein",
+  title =        "{Prospettive Relativistiche dell'etere e della
+                 Geometria}. ({Italian}) [Relativistic perspectives of
+                 the Aether and Geometry]",
+  publisher =    "Andare",
+  address =      "Milan, Italy",
+  pages =        "54",
+  year =         "1922",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 10:40:13 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translation to Italian by R. Cant{\`u} and Te. Bembo
+                 of \cite{Einstein:1920:ART,Einstein:1921:GEE}.",
+  acknowledgement = ack-nhfb,
+  language =     "Italian",
+  Schilpp-number = "153",
+}
+
+@Article{Einstein:1922:QBE,
+  author =       "Albert Einstein and Paul Ehrenfest",
+  title =        "{Quantentheoretische Bemerkungen zum Experiment von
+                 Stern und Gerlach}. ({German}) [{Quantum} Theoretical
+                 Remarks on the Experiment of {Stern} and {Gerlach}]",
+  journal =      j-Z-PHYSIK,
+  volume =       "11",
+  number =       "??",
+  pages =        "31--34",
+  month =        "????",
+  year =         "1922",
+  CODEN =        "ZEPYAA",
+  ISSN =         "0044-3328",
+  bibdate =      "Wed Nov 23 13:35:25 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "113",
+  language =     "German",
+  Schilpp-number = "164",
+  Whittaker-number = "112",
+}
+
+@Book{Einstein:1922:SRE,
+  author =       "Albert Einstein",
+  title =        "Sidelights on {Relativity}: {I}. {Ether} and
+                 {Relativity}. {II}. {Geometry} and experience",
+  publisher =    pub-METHUEN,
+  address =      pub-METHUEN:adr,
+  pages =        "3--56",
+  year =         "1922",
+  LCCN =         "QC6 .E53; Microfilm 30075 QC",
+  bibdate =      "Wed Sep 28 06:10:46 MDT 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  note =         "Translation of the German {\em {\"A}ther und
+                 Relativit{\"a}ts-Theorie\/} and {\em Geometrie und
+                 Erfahrung\/} by G. B. (George Barker) Jeffery and W.
+                 Perrett",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  Schilpp-number = "152",
+  subject =      "Relativity (physics)",
+}
+
+@InCollection{Einstein:1922:TBS,
+  author =       "Albert Einstein",
+  booktitle =    "{Leyden Rijksuniversitet Natuurkundig Laboratorium.
+                 Gedenkboek aangeboden aan H. Kamerlingh Onnes}",
+  title =        "{Theoretische Bemerkungen zur Supraleitung der
+                 Metalle}. ({German}) [{Theoretical} observations on
+                 superconductivity of metals]",
+  publisher =    "Ijdo",
+  address =      "Leyden, The Netherlands",
+  pages =        "429--435",
+  year =         "1922",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in \cite{Einstein:2005:TRS}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "110",
+  language =     "German",
+  Schilpp-number = "158",
+  Whittaker-number = "108",
+}
+
+@Article{Einstein:1922:TLD,
+  author =       "Albert Einstein",
+  title =        "{Theorie der Lichtfortpflanzung in dispergierenden
+                 Medien}. ({German}) [{Theory} of Light Propagation in
+                 Dispersive Media]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "18--22",
+  year =         "1922",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "112",
+  language =     "German",
+  Schilpp-number = "162",
+  Whittaker-number = "110",
+}
+
+@Book{Einstein:1922:UTB,
+  author =       "Albert Einstein",
+  title =        "{Untersuchung {\"u}ber die Theorie der Brownschen
+                 Bewegungen}. ({German}) [{Investigation} on the {Theory
+                 of Brownian Motion}]",
+  volume =       "199",
+  publisher =    "Akademische Verlagsgesellschaft",
+  address =      "Leipzig, Germany",
+  pages =        "72",
+  year =         "1922",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 10:57:35 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Edited by R. F{\"u}rth.",
+  series =       "Ostwalds Klassiker der exakten Wissenschaften",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "157",
+}
+
+@Book{Einstein:1922:VVR,
+  author =       "Albert Einstein",
+  title =        "{Vier Vorlesungen {\"u}ber Relativt{\"a}tstheorie,
+                 Gehalten im Mai, 1921, an der Universit{\"a}t
+                 Princeton}. ({German}) [{The} Meaning of {Relativity}:
+                 four lectures delivered at {Princeton University, May,
+                 1921}]",
+  publisher =    pub-VIEWEG,
+  address =      pub-VIEWEG:adr,
+  pages =        "70",
+  year =         "1922",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 10:50:03 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "German text of \cite{Einstein:1921:MRF}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "109a",
+  language =     "German",
+  Schilpp-number = "156",
+}
+
+@Unpublished{Einstein:1922:WIR,
+  author =       "Albert Einstein",
+  title =        "{Wie ich die Relativit{\"a}tstheorie entdeckte}.
+                 ({German}) [{How} {I} discovered the {Theory of
+                 Relativity}]",
+  day =          "14",
+  month =        dec,
+  year =         "1922",
+  bibdate =      "Fri Jul 16 09:21:52 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Lecture at the University of Kyoto, Japan.
+                 Transcription from notes by Yun Ishiwara and
+                 translation into English by Y. A. Ono in {\em Physics
+                 Today}, August 1932, page 45.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "114",
+  language =     "German",
+}
+
+@Article{Einstein:1922:WPR,
+  author =       "Albert Einstein",
+  title =        "{W. Pauli: Relativit{\"a}tstheorie}. ({German})
+                 [{Review} of {W. Pauli}: {{\em The Theory of
+                 Relativity}}]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "10",
+  number =       "??",
+  pages =        "184--185",
+  year =         "1922",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Mon Oct 30 11:00:30 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "160",
+}
+
+@Article{Einstein:1923:AFG,
+  author =       "Albert Einstein",
+  title =        "{Zur affinen Feldtheorie}. ({German}) [{On} Affine
+                 Field Theory]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "137--140",
+  year =         "1923",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Schilpp-number = "175",
+  Whittaker-number = "119",
+}
+
+@Article{Einstein:1923:ARG,
+  author =       "Albert Einstein",
+  title =        "{Zur allgemeinen Relativit{\"a}tstheorie}. ({German})
+                 [{On} the {General Theory of Relativity}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "1923",
+  number =       "??",
+  pages =        "32--38",
+  year =         "1923",
+  bibdate =      "Wed Nov 23 14:51:04 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "9.0627.01",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "116a",
+  language =     "German",
+  Whittaker-number = "118a",
+  xxjournal =    "Berl. Ber.",
+  ZMreviewer =   "F., Th",
+}
+
+@Article{Einstein:1923:BFM,
+  author =       "Albert Einstein",
+  title =        "{Bietet die Feldtheorie M{\"o}glichkeiten f{\"u}r die
+                 L{\"o}sung des Quantenproblems?}. ({German}) [{Does}
+                 field theory offer possibilities for the solution of
+                 quantum problems?]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "359--364",
+  year =         "1923",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "120",
+  language =     "German",
+  Whittaker-number = "120",
+}
+
+@Article{Einstein:1923:BMA,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung zu meiner Arbeit ``Zur allgemeinen
+                 Relativit{\"a}tstheorie''}. ({German}) [{Remarks} on my
+                 work {``On the General Theory of Relativity''}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "1923",
+  number =       "??",
+  pages =        "76--77",
+  year =         "1923",
+  bibdate =      "Wed Nov 23 14:51:04 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "9.0627.01",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "116b",
+  language =     "German",
+  Whittaker-number = "118b",
+  xxjournal =    "Berl. Ber.",
+  ZMreviewer =   "F., Th",
+}
+
+@Article{Einstein:1923:BNU,
+  author =       "Albert Einstein and J. Grommer",
+  title =        "{Beweis der Nichtexistenz eines {\"u}berall
+                 regul{\"a}ren zentrisch symmetrischen Feldes nach der
+                 Feldtheorie von Th. Kaluza}. ({German}) [{Proof} of the
+                 nonexistence of an everywhere-regular
+                 centrically0symmetrical field according to the {Field
+                 Theory of Th. Kaluza}]",
+  journal =      "Jerusalem Univ. Scripta [Scripta Universitatis atque
+                 Bibliothecae Hierosolymitanarum: Mathematica et
+                 Physica]",
+  volume =       "1",
+  number =       "7",
+  pages =        "??--??",
+  year =         "1923",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Whittaker-number = "116",
+}
+
+@Article{Einstein:1923:BNW,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung zu der Notiz von W. Anderson: Neue
+                 Erkl{\"a}rung des continuierlichen Koronaspectrums}.
+                 ({German}) [{Remark} on the note of {W. Anderson}:
+                 {``New explanation of the continuous corona
+                 spectrum''}]",
+  journal =      j-ASTRO-NACHR,
+  volume =       "219",
+  number =       "1",
+  pages =        "19--20",
+  year =         "1923",
+  CODEN =        "ASNAAN",
+  DOI =          "http://dx.doi.org/10.1002/asna.19232190103",
+  ISSN =         "0004-6337",
+  ISSN-L =       "0004-6337",
+  bibdate =      "Fri Jun 8 10:46:38 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Astronomische Nachrichten",
+  language =     "German",
+  Whittaker-number = "114",
+  xxpages =      "19--19",
+}
+
+@Article{Einstein:1923:EBK,
+  author =       "Albert Einstein and Hans M{\"u}hsam",
+  title =        "{Experimentelle Bestimmung der Kanalweite von
+                 Filtern}. ({German}) [{Experimental} determination of
+                 the channel width of filters]",
+  journal =      "Deutsch. med. Wochenschr.",
+  volume =       "49",
+  number =       "??",
+  pages =        "1012--1013",
+  year =         "1923",
+  bibdate =      "Wed Nov 23 11:36:04 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Whittaker-number = "115",
+}
+
+@InBook{Einstein:1923:GPR,
+  author =       "Albert Einstein",
+  booktitle =    "{Nobelstiftelsen}: Les prix {Nobel} en 1921--1922",
+  title =        "{Grundgedanken und Probleme der
+                 Relativit{\"a}tstheorie}. ({German}) [{Basic} idea and
+                 problems of the Theory of Relativity]",
+  publisher =    "Imprimerie royale",
+  address =      "Stockholm, Sweden",
+  pages =        "10",
+  year =         "1923",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Nobel lecture delivered in G{\"o}teborg, Sweden on
+                 July 11, 1923.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "119",
+  language =     "German",
+  remark =       "Einstein was traveling in Japan in 1922 when his prize
+                 was announced, and was unable to attend the ceremonies.
+                 Although the award was for the photoelectric effect, he
+                 lectured on Relativity instead.",
+  Whittaker-number = "113",
+}
+
+@Article{Einstein:1923:MIP,
+  author =       "Albert Einstein",
+  title =        "My Impressions of {Palestine}",
+  journal =      "New Palestine",
+  volume =       "??",
+  number =       "??",
+  pages =        "341--341",
+  year =         "1923",
+  bibdate =      "Fri Jul 16 09:25:40 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "115",
+}
+
+@Book{Einstein:1923:MRF,
+  author =       "Albert Einstein and Edwin P. (Edwin Plimpton) Adams",
+  title =        "The Meaning of {Relativity}: four lectures delivered
+                 at {Princeton University, May, 1921}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "3 + 123 + 1",
+  year =         "1923",
+  LCCN =         "QC173.58; QC6",
+  bibdate =      "Wed Nov 23 11:36:21 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  remark =       "The translation of these lectures into English was
+                 made by Edwin Plimpton Adams. Reprinted in Great
+                 Britain at the Aberdeen University Press.",
+}
+
+@Article{Einstein:1923:NAF,
+  author =       "Albert Einstein",
+  title =        "{Notiz zu der Arbeit von A. Friedmann ``{\"U}ber die
+                 Kr{\"u}mmung des Raumes''}. ({German}) [{Notice} on the
+                 work of {A. Friedmann} {``On the Curvature of
+                 Space''}]",
+  journal =      j-Z-PHYSIK,
+  volume =       "16",
+  number =       "1",
+  pages =        "228--228",
+  month =        dec,
+  year =         "1923",
+  bibdate =      "Mon Jun 04 06:21:43 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in \cite{Einstein:1986:CWF}.",
+  URL =          "http://www.springerlink.com/content/h3544p7u24671460/",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1923:QSG,
+  author =       "Albert Einstein and Paul Ehrenfest",
+  title =        "{Zur Quantentheorie des Strahlungsgleichgewichts}.
+                 ({German}) [{On} the quantum theory of the radiative
+                 equilibrium]",
+  journal =      j-Z-PHYSIK,
+  volume =       "19",
+  number =       "??",
+  pages =        "301--306",
+  year =         "1923",
+  CODEN =        "ZEPYAA",
+  DOI =          "http://dx.doi.org/10.1007/BF01327565",
+  ISSN =         "0044-3328",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "121",
+  language =     "German",
+  Whittaker-number = "122",
+}
+
+@Article{Einstein:1923:TAF,
+  author =       "Albert Einstein",
+  title =        "Theory of the affine field",
+  journal =      j-NATURE,
+  volume =       "112",
+  number =       "??",
+  pages =        "448--449",
+  year =         "1923",
+  CODEN =        "NATUAS",
+  ISSN =         "0028-0836 (print), 1476-4687 (electronic)",
+  ISSN-L =       "0028-0836",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "118",
+  journal-URL =  "http://www.nature.com/nature/archive/",
+  Whittaker-number = "117",
+}
+
+@Article{Einstein:1923:TR,
+  author =       "Albert Einstein",
+  title =        "{Theory of Relativity}",
+  journal =      j-NATURE,
+  volume =       "112",
+  number =       "??",
+  pages =        "253--253",
+  year =         "1923",
+  CODEN =        "NATUAS",
+  ISSN =         "0028-0836 (print), 1476-4687 (electronic)",
+  ISSN-L =       "0028-0836",
+  bibdate =      "Fri Jul 16 09:28:19 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation of \cite{Einstein:1923:TRF}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "117a",
+  journal-URL =  "http://www.nature.com/nature/archive/",
+}
+
+@Article{Einstein:1923:TRF,
+  author =       "Albert Einstein",
+  title =        "Th{\'e}orie de relativit{\'e}. ({French}) [{Theory of
+                 Relativity}]",
+  journal =      "Bull. Soc. philom., Paris",
+  volume =       "22",
+  number =       "??",
+  pages =        "97, 98, 101, 107, 111--112",
+  year =         "1923",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "117b",
+  fjournal =     "Bulletin de la Soci{\'e}t{\'e} fran{\c{c}}aise de
+                 philosophie",
+  language =     "French",
+  Whittaker-number = "121",
+}
+
+@Book{Lorentz:1923:PRC,
+  author =       "H. A. (Hendrik Antoon) Lorentz and Albert Einstein and
+                 H. (Hermann) Minkowski and Hermann Weyl and Arnold
+                 Sommerfeld",
+  title =        "The {Principle of Relativity}: a collection of
+                 original memoirs on the {Special and General Theory of
+                 Relativity}",
+  publisher =    pub-METHUEN,
+  address =      pub-METHUEN:adr,
+  pages =        "viii + 216",
+  year =         "1923",
+  LCCN =         "QC6 .L63",
+  bibdate =      "Mon Oct 9 07:52:59 MDT 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  note =         "Translated by W. Perrett and G. B. (George Barker)
+                 Jeffery.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1853--1928, 1879--1955, 1864--1909, 1885--1955,
+                 1868--1951",
+  remark =       "``The translations have been made from the text, as
+                 published in a German collection, under the title 'Des
+                 [!] relativit{\"a}tsprinzip' (Teubner, 4th ed., 1922)
+                 The second paper by Lorentz is an exception to
+                 this.''-- Translators' pref.",
+  subject =      "Relativity (physics)",
+}
+
+@Book{Lorentz:1923:RSA,
+  author =       "H. A. (Hendrik Antoon) Lorentz and H. (Hermann)
+                 Minkowski and Albert Einstein",
+  title =        "{Das Relativit{\"a}tsprinzip: eine Sammlung von
+                 Abhandlungen}. ({German}) [{The Principle of
+                 Relativity}: a collection of works]",
+  publisher =    pub-TEUBNER,
+  address =      pub-TEUBNER:adr,
+  edition =      "Fifth",
+  pages =        "89",
+  year =         "1923",
+  LCCN =         "????",
+  bibdate =      "Wed Nov 14 16:23:22 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1924:ABW,
+  author =       "Albert Einstein",
+  title =        "{Antwort auf eine Bemerkung von W. Anderson}.
+                 ({German}) [{Answer} to a Remark of {W. Anderson}]",
+  journal =      j-ASTRO-NACHR,
+  volume =       "221",
+  number =       "20",
+  pages =        "329--330",
+  year =         "1924",
+  CODEN =        "ASNAAN",
+  DOI =          "http://dx.doi.org/10.1002/asna.19242212004",
+  ISSN =         "0004-6337",
+  ISSN-L =       "0004-6337",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Astronomische Nachrichten",
+  language =     "German",
+  Whittaker-number = "123",
+}
+
+@Article{Einstein:1924:AGA,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber den {\"A}ther}. ({German}) [{On} the
+                 Aether]",
+  journal =      "Verh. natur. Ges. Basel",
+  volume =       "105 (part 2)",
+  number =       "??",
+  pages =        "85--93",
+  year =         "1924",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "125",
+  language =     "German",
+  Whittaker-number = "126",
+}
+
+@InCollection{Einstein:1924:GGI,
+  author =       "Albert Einstein",
+  title =        "{Geleitwort}. ({German}) [Introduction]",
+  crossref =     "Diels:1924:RNL",
+  pages =        "??--??",
+  year =         "1924",
+  bibdate =      "Wed Oct 22 14:38:02 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1924:HGL,
+  author =       "Albert Einstein",
+  title =        "{Zum hundertj{\"a}hrigen Gedentag von Lord Kelvins
+                 Geburt}. ({German}) [{On} the Hundredth Anniversary of
+                 {Lord Kelvin}'s birth]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "12",
+  number =       "??",
+  pages =        "601--602",
+  year =         "1924",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Fri Jul 16 09:37:19 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "123",
+  language =     "German",
+}
+
+@Article{Einstein:1924:KEG,
+  author =       "Albert Einstein",
+  title =        "{Das Komptonsche Experiment}. ({German}) [{The}
+                 {Compton} Experiment]",
+  journal =      "Berliner Tageblatt",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "20",
+  month =        apr,
+  year =         "1924",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "122",
+  language =     "German",
+  remark =       "1. Beiblatt.",
+  Whittaker-number = "124",
+}
+
+@Misc{Einstein:1924:LAE,
+  author =       "Albert Einstein",
+  title =        "Letter from {Albert Einstein} to the
+                 {Secretary-General of the League of Nations in
+                 Geneva}",
+  howpublished = "Web document",
+  day =          "25",
+  month =        jun,
+  year =         "1924",
+  bibdate =      "Mon Mar 10 10:12:15 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://www.wdl.org/en/item/11595/",
+  acknowledgement = ack-nhfb,
+  remark =       "From the World Digital Library document archive. The
+                 text of this short letter is in German, and the Web
+                 site provides this English translation: ``I hereby
+                 thankfully accept the renewed election to the Committee
+                 on Intellectual Cooperation. In light of my past
+                 behavior, the election means an act of special
+                 generosity of spirit, and filled me with joy as a
+                 result. I shall always try to give my best in the
+                 service of this good cause. With best high regards, A.
+                 Einstein.''",
+}
+
+@Article{Einstein:1924:QEI,
+  author =       "Albert Einstein",
+  title =        "{Quantentheorie des einatomigen idealen Gases}.
+                 ({German}) [{Quantum} Theory of Monatomic Ideal
+                 Gases]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "261--267",
+  year =         "1924",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See part 2 \cite{Einstein:1925:QEI}. In the two
+                 papers, Einstein extended Bose's work on monatomic
+                 gases \cite{Bose:1924:PGL,Bose:1924:WIS} to predict the
+                 Bose--Einstein effect (and likely, develop
+                 Bose--Einstein statistics).",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "124a",
+  fjournal =     "Sitzungsberichte der Preussischen Akademie der
+                 Wissenschaften, Physikalisch-mathematische Klasse",
+  language =     "German",
+  remark =       "See particularly \cite[Chapter 25: Quantum
+                 Dice]{Stone:2013:EQQ} for the relation between the Bose
+                 and Einstein papers that underlie Bose--Einstein
+                 statistics and Bose--Einstein condensation. On page
+                 237, Stone writes ``Bose--Einstein condensation is now
+                 one of the fundamental pillars of condensed-matter
+                 physics; it underlies the phenomena of
+                 superconductivity of solids and superfluidity of
+                 liquids such as helium at low temperatures, which have
+                 been the subject of five Nobel prizes. [Presumably,
+                 Stone refers to these, the last of which he mentions
+                 after ``five Nobel prizes'': (1) The Nobel Prize in
+                 Physics 1913 to Heike Kamerlingh Onnes ``for his
+                 investigations on the properties of matter at low
+                 temperatures which led, inter alia, to the production
+                 of liquid helium''; (2) The Nobel Prize in Physics 1962
+                 to Lev Davidovich Landau, ``for his pioneering theories
+                 for condensed matter, especially liquid helium''; (3)
+                 The Nobel Prize in Physics 1973 to Leo Esaki and Ivar
+                 Giaever ``for their experimental discoveries regarding
+                 tunneling phenomena in semiconductors and
+                 superconductors, respectively'', and to Brian David
+                 Josephson ``for his theoretical predictions of the
+                 properties of a supercurrent through a tunnel barrier,
+                 in particular those phenomena which are generally known
+                 as the Josephson effects'' (4) The Nobel Prize in
+                 Physics 1996 to David M. Lee, Douglas D. Osheroff and
+                 Robert C. Richardson ``for their discovery of
+                 superfluidity in helium-3''; (5) The Nobel Prize in
+                 Physics 2001 to Eric A. Cornell, Wolfgang Ketterle and
+                 Carl E. Wieman, ``for the achievement of Bose-Einstein
+                 condensation in dilute gases of alkali atoms, and for
+                 early fundamental studies of the properties of the
+                 condensates'' (6) The Nobel Prize in Physics 2003 to
+                 Alexei A. Abrikosov, Vitaly L. Ginzburg and Anthony J.
+                 Leggett, ``for pioneering contributions to the theory
+                 of superconductors and superfluids''.]",
+  Whittaker-number = "125a",
+}
+
+@Article{Einstein:1924:RE,
+  author =       "A. Einstein",
+  title =        "Review of {Elsbach} 1924",
+  journal =      "Deutsche Literaturzeitung",
+  volume =       "45",
+  number =       "??",
+  pages =        "1688--1689",
+  month =        "????",
+  year =         "1924",
+  bibdate =      "Wed Dec 14 05:51:33 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See \cite{Elsbach:1924:KEU}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "http://plato.stanford.edu/entries/einstein-philscience/
+                 says ``An especially interesting example is found in a
+                 review that Einstein wrote in 1924 of Alfred Elsbach's
+                 Kant und Einstein (1924)\ldots{}''.",
+  xxnote =       "Find German title??",
+}
+
+@Article{Einstein:1924:RGB,
+  author =       "Albert Einstein",
+  title =        "{[Rezension]}. ({German}) [Book Review]",
+  journal =      "{Deutsche Literaturzeitung}",
+  volume =       "1",
+  number =       "??",
+  pages =        "20--??",
+  month =        "????",
+  year =         "1924",
+  bibdate =      "Wed Oct 22 15:09:26 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  xxnote =       "Find correct title?? (absent from \cite[page 133,
+                 reference 43]{Pais:1994:ELH}). Also cited online and in
+                 \cite[page 13]{Howard:1994:KVW} as ``Review of Elsbach
+                 1924. Deutsche Literaturzeitung 45, 1688--1689.''",
+}
+
+@Article{Einstein:1924:TRG,
+  author =       "Albert Einstein",
+  title =        "{Zur Theorie der Radiometerkr{\"a}fte}. ({German})
+                 [{On} the Theory of Radiometric Forces]",
+  journal =      j-Z-PHYSIK,
+  volume =       "27",
+  number =       "??",
+  pages =        "1--6",
+  year =         "1924",
+  CODEN =        "ZEPYAA",
+  ISSN =         "0044-3328",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "126",
+  language =     "German",
+  Whittaker-number = "127",
+}
+
+@Article{Einstein:1925:ABW,
+  author =       "Albert Einstein",
+  title =        "{Addendum to Bose, Warmegleichgewicht im
+                 Strahlungsfeld bei Anwesenheit von Materie}. ({German})
+                 [{Addendum} to {Bose}, ``Thermal Equilibrium in
+                 Radiation Fields in the Presence of Matter'']",
+  journal =      j-Z-PHYSIK,
+  volume =       "27",
+  number =       "??",
+  pages =        "392--393",
+  year =         "1925",
+  CODEN =        "ZEPYAA",
+  ISSN =         "0044-3328",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Whittaker-number = "128",
+}
+
+@Article{Einstein:1925:BPJ,
+  author =       "Albert Einstein",
+  title =        "{Bemerkung zu P. Jordans Abhandlung: Theorie der
+                 Quantenstrahlung}. ({German}) [{Remark} on {P.
+                 Jordan}'s paper: {``Theory of Quantum Radiation}'']",
+  journal =      j-Z-PHYSIK,
+  volume =       "31",
+  number =       "??",
+  pages =        "784--785",
+  year =         "1925",
+  CODEN =        "ZEPYAA",
+  ISSN =         "0044-3328",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Whittaker-number = "133",
+}
+
+@Article{Einstein:1925:EAR,
+  author =       "Albert Einstein",
+  title =        "{Elektron und allgemeine Relativit{\"a}tstheorie}.
+                 ({German}) [{The} Electron and the {General Theory of
+                 Relativity}]",
+  journal =      j-PHYSICA,
+  volume =       "5",
+  number =       "??",
+  pages =        "330--334",
+  year =         "1925",
+  CODEN =        "PHYSAG",
+  ISSN =         "0031-8914 (print), 1873-1767 (electronic)",
+  ISSN-L =       "0031-8914",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "129",
+  fjournal =     "Physica",
+  journal-URL =  "http://www.sciencedirect.com/science/journal/00318914/",
+  language =     "German",
+  Whittaker-number = "130",
+  xxnote =       "Resolve serious discrepancy in title! Calaprice has
+                 the xxtitle value.",
+  xxtitle =      "{Elektron und einheitlichen Feldtheorie}. ({German})
+                 [{The} Electron and {Unified Field Theory}]",
+}
+
+@Article{Einstein:1925:EFG,
+  author =       "Albert Einstein",
+  title =        "{Einheitliche Feldtheorie von Gravitation und
+                 Elektrizit{\"a}t}. ({German}) [{Unified Field Theory}
+                 of Gravitation and Electricity]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "414--419",
+  year =         "1925",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "128",
+  language =     "German",
+  Whittaker-number = "132",
+}
+
+@InCollection{Einstein:1925:ETH,
+  author =       "Albert Einstein",
+  editor =       "Sir Arthur Stanley Eddington",
+  booktitle =    "{Relativit{\"a}tstheorie in mathematischer
+                 Behandlung}. ({German}) [{The} {Theory of Relativity}
+                 in Mathematical Treatment]",
+  title =        "{Eddingtons Theorie und Hamiltonsches Prinzip}.
+                 ({German}) [{Eddington}'s Theory and the {Hamiltonian
+                 Principle}]",
+  publisher =    pub-SV,
+  address =      pub-SV:adr,
+  pages =        "366--371",
+  year =         "1925",
+  bibdate =      "Fri Jul 16 09:48:23 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Appendix",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "131",
+  language =     "German",
+  Whittaker-number = "129",
+}
+
+@Article{Einstein:1925:MOU,
+  author =       "Albert Einstein",
+  title =        "Mission of Our University",
+  journal =      "New Palestine",
+  volume =       "8",
+  number =       "??",
+  pages =        "294--294",
+  year =         "1925",
+  bibdate =      "Fri Jul 16 09:43:05 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "127",
+}
+
+@Article{Einstein:1925:PE,
+  author =       "Albert Einstein",
+  title =        "Pan {Europa}",
+  journal =      "La Prensa [{Buenos Aires??}]",
+  volume =       "??",
+  number =       "??",
+  pages =        "4--4",
+  day =          "24",
+  month =        mar,
+  year =         "1925",
+  bibdate =      "Thu Jul 25 17:27:31 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "Spanish",
+}
+
+@Article{Einstein:1925:QEI,
+  author =       "Albert Einstein",
+  title =        "{Quantentheorie des einatomigen idealen Gases}.
+                 ({German}) [{Quantum} Theory of Monatomic Ideal
+                 Gases]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "3--14",
+  year =         "1925",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See part 1 \cite{Einstein:1924:QEI}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "124b",
+  language =     "German",
+  remark =       "See particularly \cite[Chapter 25: Quantum
+                 Dice]{Stone:2013:EQQ} for the relation between the Bose
+                 and Einstein papers that underlie Bose--Einstein
+                 statistics and Bose--Einstein condensation.",
+  Whittaker-number = "125b",
+}
+
+@Article{Einstein:1925:QIG,
+  author =       "Albert Einstein",
+  title =        "{Quantentheorie des idealen Gases}. ({German})
+                 [{Quantum} Theory of Ideal Gases]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "18--25",
+  year =         "1925",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "This paper predicts Bose--Einstein condensation.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "124c, 130",
+  language =     "German",
+  Whittaker-number = "131",
+}
+
+@Article{Einstein:1925:RPR,
+  author =       "Albert Einstein and A. N. Whitehead and G. B. Jeffery
+                 and F. D. Murnaghan and W. Perrett",
+  title =        "Recent Publications: Reviews: {Sidelights on
+                 Relativity} // {The Principle of Relativity with
+                 Applications to Physical Science}",
+  journal =      j-AMER-MATH-MONTHLY,
+  volume =       "32",
+  number =       "6",
+  pages =        "311--313",
+  year =         "1925",
+  CODEN =        "AMMYAE",
+  ISSN =         "0002-9890 (print), 1930-0972 (electronic)",
+  ISSN-L =       "0002-9890",
+  MRclass =      "Contributed Item",
+  MRnumber =     "MR1520714",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "The American Mathematical Monthly",
+}
+
+@Article{Einstein:1926:GNE,
+  author =       "Albert Einstein",
+  title =        "Geometria no euclidea y fisica. ({Spanish})
+                 [{Non-Euclidean} Geometry and Physics]",
+  journal =      "Revista mathematica hispano-america ({Buenos-Aires}),
+                 series 2",
+  volume =       "1",
+  number =       "??",
+  pages =        "72--76",
+  day =          "16",
+  month =        apr,
+  year =         "1926",
+  bibdate =      "Fri Oct 27 14:33:27 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "Spanish",
+}
+
+@Article{Einstein:1926:IDK,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber die Interferenzeigenschaften des durch
+                 Kanalstrahlen emittierten Lichtes}. ({German}) [{On}
+                 the interference characteristics of light emitted by
+                 canal rays]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "334--340",
+  year =         "1926",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "134",
+  language =     "German",
+  Whittaker-number = "135",
+}
+
+@Article{Einstein:1926:UMF,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber die Ursache der Ma{\"a}nderbildung der
+                 Flussl{\"a}ufe und des sogenannten Baerschen Gesetzes}.
+                 ({German}) [{On} the Causes of meandering of river
+                 courses and the so-called {Baer Law}]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "14",
+  number =       "??",
+  pages =        "223--224",
+  year =         "1926",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Read before the Prussian Academy of Sciences on 7
+                 January 1926. English translation in
+                 \cite{Einstein:1934:WSI} and
+                 \cite[pp.~249--253]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "132",
+  language =     "German",
+  Whittaker-number = "134",
+}
+
+@Article{Einstein:1926:VEN,
+  author =       "Albert Einstein",
+  title =        "{Vorschlag zu einem die Natu des elementaren
+                 Strahlungs-Emissions-prozesses betreffendes
+                 Experiment}. ({German}) [{Suggestion} for an Experiment
+                 on the Nature of the Elementary Radiation Emission
+                 Process]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "14",
+  number =       "??",
+  pages =        "300--301",
+  year =         "1926",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Fri Jul 16 09:57:31 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "133",
+  language =     "German",
+}
+
+@Misc{Szilard:1926:CBL,
+  author =       "Leo Szilard and Albert Einstein",
+  title =        "[Correspondence between {Leo Szilard} and {Albert
+                 Einstein}]",
+  howpublished = "Personal and scientific correspondence between the
+                 authors.",
+  pages =        "132",
+  year =         "1926--1945",
+  bibdate =      "Thu May 21 06:36:09 2015",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/s/szilard-leo.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://library.ucsd.edu/dc/object/bb24247539",
+  acknowledgement = ack-nhfb,
+  remark =       "The draft of the 1939 Einstein--Roosevelt letter that
+                 Szilard prepared does not appear in the here, but there
+                 is a pointer to a copy of that letter in the Harold
+                 Urey papers. There are, however, copies of the final
+                 version; the original is held with the FDR Papers in
+                 Hyde Park, NY.",
+}
+
+@Article{Curie:1927:EIB,
+  author =       "M. Curie and H. A. Lorentz and A. Einstein",
+  title =        "The establishment of an {International Bureau of
+                 Meteorology}",
+  journal =      j-SCIENCE,
+  volume =       "65",
+  number =       "??",
+  pages =        "415--417",
+  month =        "????",
+  year =         "1927",
+  CODEN =        "SCIEAS",
+  ISSN =         "0036-8075 (print), 1095-9203 (electronic)",
+  ISSN-L =       "0036-8075",
+  bibdate =      "Wed Nov 23 13:34:06 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  journal-URL =  "http://www.sciencemag.org/archive/",
+}
+
+@Article{Einstein:1927:ARBa,
+  author =       "Albert Einstein and Jakob Grommer",
+  title =        "{Allgemeine Relativit{\"a}tstheorie und
+                 Bewegungsgesetze}. ({German}) [{The General Theory of
+                 Relativity} and the {Law of Motion}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "2--13",
+  year =         "1927",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Whittaker-number = "139a",
+}
+
+@Article{Einstein:1927:ARBb,
+  author =       "Albert Einstein and Jakob Grommer",
+  title =        "{Allgemeine Relativit{\"a}tstheorie und
+                 Bewegungsgesetze}. ({German}) [{The General Theory of
+                 Relativity} and the {Law of Motion}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "235--245",
+  year =         "1927",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "140",
+  language =     "German",
+  Whittaker-number = "139b",
+}
+
+@Unpublished{Einstein:1927:BSW,
+  author =       "Albert Einstein",
+  title =        "{Bestimmt Schr{\"o}dingers Wellenmechanik die Bewegung
+                 eines Systems vollst{\"a}ndig oder nur im Sinne der
+                 Statistik?} ({German}) [{Does} {Schr{\"o}dinger}'s wave
+                 mechanics determine the motion of a system completely,
+                 or only in the sense of statistics?]",
+  day =          "5",
+  month =        may,
+  year =         "1927",
+  bibdate =      "Wed Jun 03 07:03:35 2015",
+  note =         "Read before the Prussian Academy of Sciences, but
+                 never published.",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/s/schroedinger-erwin.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://alberteinstein.info/vufind1/Record/EAR000034338",
+  acknowledgement = ack-nhfb,
+  remark =       "Vaguely cited in English title translation in
+                 \cite[page 116]{Baggott:2011:QSH}, and with the
+                 original German title in \cite[page
+                 ??]{Atmanspacher:2014:PJC}. Fine \cite[page
+                 98]{Fine:2012:SG}, says ``Einstein never allowed this
+                 manuscript to be published.''",
+}
+
+@Article{Einstein:1927:EEL,
+  author =       "Albert Einstein",
+  title =        "{Einfluss der Erdbewegung auf die Lichtgeschwindigkeit
+                 relative zur Erde}. ({German}) [{Influence} of the
+                 {Earth} movement on the speed of light relative to the
+                 {Earth}]",
+  journal =      "Forsch. Fortschr. dtsch. Wiss.",
+  volume =       "3",
+  number =       "??",
+  pages =        "36--37",
+  year =         "1927",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "136",
+  fjournal =     "Forschung und Fortschritte [Research and Progress]",
+  language =     "German",
+  Whittaker-number = "136",
+}
+
+@Article{Einstein:1927:FBR,
+  author =       "A. Einstein",
+  title =        "{{\"U}ber die formale Beziehung des Riemannschen
+                 Kr{\"u}mmungstensors zu den Feldgleichungen der
+                 Gravitation}. ({German}) [{The} formal relationship of
+                 the {Riemann} curvature tensor to the field equations
+                 of gravitation]",
+  journal =      j-MATH-ANN,
+  volume =       "97",
+  number =       "1",
+  pages =        "99--103",
+  year =         "1927",
+  CODEN =        "MAANA3",
+  ISSN =         "0025-5831 (print), 1432-1807 (electronic)",
+  ISSN-L =       "0025-5831",
+  MRclass =      "Contributed Item",
+  MRnumber =     "MR1512356",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "137",
+  fjournal =     "Mathematische Annalen",
+  language =     "German",
+  Whittaker-number = "137",
+}
+
+@Article{Einstein:1927:IN,
+  author =       "Albert Einstein",
+  title =        "{Isaac Newton}",
+  journal =      j-NATURE,
+  volume =       "119",
+  number =       "??",
+  pages =        "467--467",
+  year =         "1927",
+  CODEN =        "NATUAS",
+  ISSN =         "0028-0836 (print), 1476-4687 (electronic)",
+  ISSN-L =       "0028-0836",
+  bibdate =      "Fri Jul 16 10:14:02 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Letter to the Royal Society on the two-hundredth
+                 anniversary of Newton's death. English translation in
+                 \cite[pp.~253--261]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "139",
+  journal-URL =  "http://www.nature.com/nature/archive/",
+}
+
+@Article{Einstein:1927:KTZ,
+  author =       "Albert Einstein",
+  title =        "{Zur Kaluzas Theorie des Zusammenhanges von
+                 Gravitation und Elektrizit{\"a}t}. ({German}) [{On}
+                 {Kaluza}'s Theory on the Relation of Gravitation and
+                 Electricity]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "23--30",
+  year =         "1927",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "135",
+  keywords =     "Kaluza--Klein field equations",
+  language =     "German",
+  Whittaker-number = "138",
+}
+
+@Article{Einstein:1927:NMI,
+  author =       "Albert Einstein",
+  title =        "{Newtons Mechanik und ihr Einfluss auf die Gestaltung
+                 der theoretischen Physik}. ({German}) [{Newton}'s
+                 Mechanics and Its Influence on the Shaping of
+                 Theoretical Physics]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "15",
+  number =       "??",
+  pages =        "273--276",
+  year =         "1927",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Fri Jul 16 10:09:19 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Essay written on the two-hundredth anniversary of
+                 Newton's death. English translation in
+                 \cite{Einstein:1934:WSI} and \cite{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "138",
+  language =     "German",
+}
+
+@Article{Born:1928:PMG,
+  author =       "M. Born and A. Einstein and M. v. Laue and E.
+                 Schr{\"o}dinger and A. Sommerfeld",
+  title =        "{Planck-Medaille}. ({German}) [{Planck Medal}]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "16",
+  number =       "20",
+  pages =        "368--368",
+  month =        may,
+  year =         "1928",
+  CODEN =        "NATWAY",
+  DOI =          "http://dx.doi.org/10.1007/BF01505421",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Mon Jun 11 06:29:50 MDT 2012",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/b/born-max.bib;
+                 http://www.math.utah.edu/pub/bibnet/authors/s/schroedinger-erwin.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://www.springerlink.com/content/gg356437362203j2/fulltext.pdf",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Naturwissenschaften",
+  language =     "German",
+}
+
+@Article{Einstein:1928:HL,
+  author =       "Albert Einstein",
+  title =        "{H. A. Lorentz}",
+  journal =      "Mathematisch-naturwissenschaftliche Bl{\"a}tter",
+  volume =       "22",
+  number =       "??",
+  pages =        "24--25",
+  year =         "1928",
+  bibdate =      "Fri Jul 16 10:19:45 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted as ``Address at the Grave of H. A. Lorentz''
+                 in \cite{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "143",
+}
+
+@InCollection{Einstein:1928:IN,
+  author =       "Albert Einstein",
+  editor =       "C. G. Abbot",
+  booktitle =    "{Annual Report of the Board of Regents of The
+                 Smithsonian Institution, Showing the Operations,
+                 Expenditures, and Condition of the Institution for the
+                 Year Ending June 30, 1927}",
+  title =        "{Isaac Newton}",
+  publisher =    pub-USGPO,
+  address =      pub-USGPO:adr,
+  bookpages =    "580",
+  pages =        "201--208",
+  year =         "1928",
+  bibdate =      "Wed Oct 22 15:24:18 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See corrigendum \cite{}.",
+  URL =          "https://archive.org/stream/annualreportofbo1927smit/annualreportofbo1927smit_djvu.txt",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1928:NME,
+  author =       "Albert Einstein",
+  title =        "{Neue M{\"o}glichkeiten f{\"u}r eine einheitliche
+                 Feldtheorie von Gravitation und Elektrizit{\"a}t}.
+                 ({German}) [{New} Possibilities for a Unified Field
+                 Theory of Gravitation and Electricity]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "224--227",
+  year =         "1928",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "142",
+  language =     "German",
+  Whittaker-number = "141",
+}
+
+@Article{Einstein:1928:PDR,
+  author =       "Albert Einstein",
+  title =        "A propos de {`La d{\'e}duction relativiste'} de {M. E.
+                 Meyerson}. ({French}) [On {M. E. Meyerson}'s article
+                 {``Relativistic Deduction''}]",
+  journal =      "Revue Philosophique de {France}",
+  volume =       "105",
+  number =       "??",
+  pages =        "161--166",
+  year =         "1928",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  ajournal =     "Rev. phil. France",
+  language =     "French",
+  Whittaker-number = "142",
+}
+
+@Article{Einstein:1928:RGA,
+  author =       "Albert Einstein",
+  title =        "{Riemann-geometrie mit Aufrechterhaltung des Begriffes
+                 des Fernparallelismus}. ({German}) [{Riemannian}
+                 geometry with preservation of distant parallelism]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "217--221",
+  year =         "1928",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "141",
+  language =     "German",
+  Whittaker-number = "140",
+}
+
+@Misc{Szilard:1928:EMF,
+  author =       "Leo Szilard and Albert Einstein",
+  title =        "Electrodynamic Movement of Fluid Metals particularly
+                 for Refrigerating Machines",
+  howpublished = "British Patent No. 303,065 (filed December 24, 1928,
+                 issued May 26, 1930)",
+  day =          "24",
+  month =        dec,
+  year =         "1928",
+  bibdate =      "Sat Apr 25 15:37:31 2015",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/s/szilard-leo.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite[pages 540--542]{Feld:1972:CWL}.",
+  acknowledgement = ack-nhfb,
+}
+
+@Unpublished{Einstein:1929:BST,
+  author =       "Albert Einstein",
+  title =        "Broadcast on the semicentennial of {Thomas A.
+                 Edison}'s incandescent light",
+  year =         "1929",
+  bibdate =      "Fri Jul 16 10:22:29 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in the New York Times, October 23, 1929",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "144",
+}
+
+@Article{Einstein:1929:EFG,
+  author =       "Albert Einstein",
+  title =        "{Zur Einheitlichen Feldtheorie}. ({German}) [{On} the
+                 {Unified Field Theory}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "2--7",
+  year =         "1929",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "145",
+  language =     "German",
+  Whittaker-number = "145",
+}
+
+@Article{Einstein:1929:EFH,
+  author =       "Albert Einstein",
+  title =        "{Einheitliche Feldtheorie und Hamiltonsches Prinzip}.
+                 ({German}) [{Unified Field Theory} and the {Hamiltonian
+                 Principle}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "156--159",
+  year =         "1929",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "148",
+  language =     "German",
+  Whittaker-number = "146",
+}
+
+@Article{Einstein:1929:EIG,
+  author =       "Albert Einstein",
+  title =        "{Einheitliche Interpretation von Gravitation un
+                 Elektrizit{\"a}t}. ({German}) [{Unified} Interpretation
+                 of Gravitation and Electricity]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "102--102",
+  year =         "1929",
+  bibdate =      "Fri Jul 16 10:26:26 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "147",
+  language =     "German",
+}
+
+@InCollection{Einstein:1929:GSF,
+  author =       "Albert Einstein",
+  editor =       "E. Honegger",
+  booktitle =    "{Festschrift f{\"u}r Professor A. Stodola}. ({German})
+                 [Festschrift for {Professor A. Stodola}]",
+  title =        "{{\"U}ber den gegenw{\"a}rtigen Stand der
+                 Feldtheorie}. ({German}) [{On} the current status of
+                 field theory]",
+  publisher =    "Orel F{\"u}ssli Verlag",
+  address =      "Z{\"u}rich, Switzerland",
+  pages =        "126--132",
+  year =         "1929",
+  bibdate =      "Wed Oct 22 15:15:36 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1929:NFTa,
+  author =       "Albert Einstein",
+  title =        "The New Field Theory",
+  journal =      j-NY-TIMES,
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "3",
+  month =        feb,
+  year =         "1929",
+  CODEN =        "NYTIAO",
+  ISSN =         "0362-4331 (print), 1542-667X, 1553-8095",
+  ISSN-L =       "0362-4331",
+  bibdate =      "Fri Jul 16 10:24:13 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Report on \cite{Einstein:1929:EFG}",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "146",
+}
+
+@Article{Einstein:1929:NFTb,
+  author =       "Albert Einstein",
+  title =        "The New Field Theory",
+  journal =      "The Times, London",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "4",
+  month =        feb,
+  year =         "1929",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Whittaker-number = "144",
+}
+
+@Article{Einstein:1929:SEA,
+  author =       "Albert Einstein",
+  title =        "Sesi{\'o}n especial de la Academia, {16 April 1925}",
+  journal =      "An. Soc. cient. argent.",
+  volume =       "107",
+  number =       "??",
+  pages =        "337--347",
+  year =         "1929",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Whittaker-number = "148",
+}
+
+@InCollection{Einstein:1929:STa,
+  author =       "Albert Einstein",
+  booktitle =    "{Encyclopaedia Brittanica}",
+  title =        "Space--time",
+  volume =       "21",
+  publisher =    "????",
+  address =      "????",
+  edition =      "14th",
+  pages =        "105--108",
+  year =         "1929",
+  LCCN =         "????",
+  bibdate =      "Sat Oct 28 11:16:47 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Whittaker-number = "143",
+}
+
+@Article{Einstein:1929:STb,
+  author =       "Albert Einstein",
+  title =        "On Scientific Truth",
+  journal =      "Gelegentliches",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  year =         "1929",
+  bibdate =      "Fri Aug 13 09:37:29 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Answers to questions from a Japanese scholar. English
+                 translation in \cite[pp.~261--262]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+  xxtitle =      "What is original German title?? Find missing
+                 fields??",
+}
+
+@Article{Einstein:1929:TSC,
+  author =       "Albert Einstein and Th. de Donder",
+  title =        "La th{\'e}orie synth{\'e}tique des champs. ({French})
+                 [{The} Synthetic Theory of Fields]",
+  journal =      "Revue g{\'e}n{\'e}ral de l'{\'e}lectricit{\'e}",
+  volume =       "25",
+  number =       "??",
+  pages =        "35--39",
+  year =         "1929",
+  ISSN =         "0035-3116",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+  Whittaker-number = "147",
+  xxnote =       "Check author order??",
+}
+
+@Article{Einstein:1930:BGB,
+  author =       "Albert Einstein",
+  title =        "{[Besprechung]}. ({German}) [Book Review]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "18",
+  number =       "22",
+  pages =        "536--536",
+  day =          "30",
+  month =        may,
+  year =         "1930",
+  CODEN =        "NATWAY",
+  DOI =          "http://dx.doi.org/10.1007/BF01513429",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Wed Oct 22 15:06:36 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://link.springer.com/article/10.1007/BF01513429",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Naturwissenschaften",
+  journal-URL =  "http://link.springer.com/journal/114",
+  language =     "German",
+}
+
+@Article{Einstein:1930:CS,
+  author =       "Albert Einstein",
+  title =        "Concept of Space",
+  journal =      j-NATURE,
+  volume =       "125",
+  number =       "??",
+  pages =        "897--898",
+  year =         "1930",
+  CODEN =        "NATUAS",
+  ISSN =         "0028-0836 (print), 1476-4687 (electronic)",
+  ISSN-L =       "0028-0836",
+  bibdate =      "Fri Jul 16 10:43:59 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "159",
+  journal-URL =  "http://www.nature.com/nature/archive/",
+}
+
+@Article{Einstein:1930:FEF,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber die Fortschritte der einheitlichen
+                 Feldtheorie}. ({German}) [{On} Progress Made by the
+                 {Unified Field Theory}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "102--102",
+  year =         "1930",
+  bibdate =      "Fri Jul 16 10:31:14 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "151",
+  language =     "German",
+}
+
+@Article{Einstein:1930:GSA,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber den gegenwartigen stand der allgemeinen
+                 Relativit{\"a}tstheorie}. ({German}) [{On} the current
+                 state of the {General Theory of Relativity}]",
+  journal =      "Yale Univ. Lib. Gaz.",
+  volume =       "6",
+  number =       "??",
+  pages =        "3--6",
+  year =         "1930",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "160",
+  language =     "German",
+  Whittaker-number = "155",
+}
+
+@Article{Einstein:1930:KFE,
+  author =       "Albert Einstein",
+  title =        "{Die Kompatibilit{\"a}t der Feldgleichungen in der
+                 einheitlichen Feldtheorie}. ({German}) [{Compatibility}
+                 of the field equations in {Uniform Field Theory}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "18--23",
+  year =         "1930",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "149",
+  language =     "German",
+  Whittaker-number = "152",
+}
+
+@Article{Einstein:1930:KGA,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber Kepler}. ({German}) [{About Kepler}]",
+  journal =      "Frankfurter Zeitung",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "9",
+  month =        nov,
+  year =         "1930",
+  bibdate =      "Fri Jul 16 10:36:47 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Written on the three-hundredth anniversary of the
+                 death of Johannes Kepler. English translation in
+                 \cite{Einstein:1934:WSI} and
+                 \cite[pp.~262--266]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "155",
+  language =     "German",
+}
+
+@Misc{Einstein:1930:R,
+  author =       "Albert Einstein and Leo Szilard",
+  title =        "Refrigeration",
+  howpublished = "US Patent 1,781,541.",
+  pages =        "4",
+  day =          "11",
+  month =        nov,
+  year =         "1930",
+  bibdate =      "Tue Sep 13 15:09:21 2011",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/s/szilard-leo.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Application filed December 16, 1927 (serial number
+                 240,566) and in Germany, December 16, 1926. See
+                 \cite{Dannen:1997:ESR,Dannen:1997:SRD} for accounts of
+                 this invention.",
+  URL =          "http://www.google.com/patents?id=t0BRAAAAEBAJ",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1930:RAFa,
+  author =       "Albert Einstein",
+  title =        "{Raum, {\"A}ther und Feld in der Physik}. ({German})
+                 [{Space}, Aether and Field in Physics]",
+  journal =      "Forum philosophicum",
+  volume =       "1",
+  number =       "??",
+  pages =        "173--180",
+  year =         "1930",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "154",
+  language =     "German",
+  Whittaker-number = "149",
+}
+
+@Article{Einstein:1930:RAFb,
+  author =       "A. Einstein",
+  title =        "{Das Raum-, {\"A}ther- und Feld-Problem der Physik}.
+                 ({German}) [{Space}, Ether, and Field Problems of
+                 Physics]",
+  journal =      "Transactions of the World Power Conference, 2nd,
+                 Berlin",
+  volume =       "19",
+  number =       "??",
+  pages =        "1--5",
+  year =         "1930",
+  bibdate =      "Wed Dec 14 05:56:28 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in
+                 \cite[276--285]{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1930:RFG,
+  author =       "Albert Einstein",
+  title =        "{Rede zur Funkausstellung}. ({German}) [{Speech} at
+                 the {Broadcasting Exhibition}]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "49",
+  pages =        "33--33",
+  year =         "1930",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Fri Jul 16 10:46:58 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Transcribed by F. Herneck from the sound recording
+                 made in Berlin, August 22, 1930.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "162",
+  language =     "German",
+}
+
+@Article{Einstein:1930:RMF,
+  author =       "A. Einstein",
+  title =        "{Auf die Riemann-Metrik und den Fern-Parallelismus
+                 gegr{\"u}ndete einheitliche Feldtheorie}. ({German})
+                 [{On} the {Riemann Metric} and the distant parallelism
+                 created by {Uniform Field Theory}]",
+  journal =      j-MATH-ANN,
+  volume =       "102",
+  number =       "1",
+  pages =        "685--697",
+  year =         "1930",
+  CODEN =        "MAANA3",
+  ISSN =         "0025-5831 (print), 1432-1807 (electronic)",
+  ISSN-L =       "0025-5831",
+  MRclass =      "Contributed Item",
+  MRnumber =     "MR1512601",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://www.lrz-muenchen.de/~u7f01bf/WWW/einstein1930.intro.html",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "153",
+  fjournal =     "Mathematische Annalen",
+  language =     "German",
+  remark =       "English translation available at links from the URL.",
+  Whittaker-number = "151",
+}
+
+@Article{Einstein:1930:RS,
+  author =       "Albert Einstein",
+  title =        "Religion and Science",
+  journal =      j-NY-TIMES,
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "9",
+  month =        nov,
+  year =         "1930",
+  CODEN =        "NYTIAO",
+  ISSN =         "0362-4331 (print), 1542-667X, 1553-8095",
+  ISSN-L =       "0362-4331",
+  bibdate =      "Fri Jul 16 10:38:53 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite{Einstein:1931:CRO} and \cite[pages
+                 36--40]{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "156",
+}
+
+@Article{Einstein:1930:RWG,
+  author =       "Albert Einstein",
+  title =        "{Religion und Wissenschaft}. ({German}) [{Religion}
+                 and Science]",
+  journal =      "{Berliner Tageblatt}",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "11",
+  month =        nov,
+  year =         "1930",
+  bibdate =      "Fri Jul 26 16:29:21 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1930:RZP,
+  author =       "Albert Einstein",
+  title =        "{Das Raum-Zeit Problem}. ({German}) [{The} Space--time
+                 Problem]",
+  journal =      "Koralle",
+  volume =       "5",
+  number =       "??",
+  pages =        "486--488",
+  year =         "1930",
+  bibdate =      "Fri Jul 16 10:45:14 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "161",
+  language =     "German",
+}
+
+@InCollection{Einstein:1930:SD,
+  author =       "Albert Einstein",
+  editor =       "Otto Forst-Battaglia",
+  booktitle =    "{Prozess der diktatur}. ({German}) [{Dictatorship} on
+                 its trial]",
+  title =        "Science and Dictatorship",
+  publisher =    "G. G. Harrap \& Co. Ltd.",
+  address =      "London, UK",
+  bookpages =    "389 + 1",
+  pages =        "??--??",
+  year =         "1930",
+  LCCN =         "D107 .F65",
+  bibdate =      "Sat Jul 17 09:02:04 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "163",
+  language =     "German",
+  remark =       "English translation in \cite{Einstein:1970:SD}.
+                 Einstein's contribution is only two lines.",
+}
+
+@Article{Einstein:1930:SGD,
+  author =       "Albert Einstein",
+  title =        "Science and {God}: a Dialogue",
+  journal =      "Forum and Century",
+  volume =       "83",
+  number =       "??",
+  pages =        "373--379",
+  year =         "1930",
+  bibdate =      "Fri Jul 16 10:41:12 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "157",
+  remark =       "Based on a conversation with J. Murphy and J. W. N.
+                 Sullivan.",
+}
+
+@Article{Einstein:1930:TRR,
+  author =       "Albert Einstein",
+  title =        "{Zur Theorie der R{\"a}ume mit Riemann-metrik und
+                 Fernparallelismus}. ({German}) [{Theory} of space with
+                 {Riemann} metrics and distant parallelism]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "401--402",
+  year =         "1930",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "152",
+  language =     "German",
+  Whittaker-number = "154",
+}
+
+@Article{Einstein:1930:TUD,
+  author =       "A. Einstein",
+  title =        "Th{\'e}orie unitaire du champ physique. ({French})
+                 [{The} unitary theory of the physical field]",
+  journal =      "Ann. Inst. H. Poincar{\'e}",
+  volume =       "1",
+  number =       "1",
+  pages =        "1--24",
+  year =         "1930",
+  ISSN =         "0365-320X",
+  MRclass =      "Contributed Item",
+  MRnumber =     "MR1507981",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://www.numdam.org/item?id=AIHP_1930__1_1_1_0",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annales de l'Institut Henri Poincar{\'e}",
+  language =     "French",
+  Whittaker-number = "150",
+}
+
+@Article{Einstein:1930:WB,
+  author =       "Albert Einstein",
+  title =        "What {I} Believe",
+  journal =      "Forum and Century",
+  volume =       "84",
+  number =       "??",
+  pages =        "193--194",
+  year =         "1930",
+  bibdate =      "Fri Jul 16 10:42:44 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite[pages 8--11]{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "158",
+}
+
+@Article{Einstein:1930:ZSS,
+  author =       "Albert Einstein and Walter Mayer",
+  title =        "{Zwei strenge statische L{\'o}sungen der
+                 Feldgleichungen der einheitlichen Feldtheorie}.
+                 ({German}) [{Two} strict static solutions of the field
+                 equations of {Uniform Field Theory}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "110--120",
+  year =         "1930",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "150",
+  language =     "German",
+  Whittaker-number = "153",
+  xxnote =       "Calaprice has statistiche (statistical). Check!",
+}
+
+@Book{Einstein:1931:AZS,
+  author =       "Albert Einstein",
+  title =        "About {Zionism}: speeches and letters",
+  publisher =    pub-MACMILLAN,
+  address =      pub-MACMILLAN:adr,
+  pages =        "94 (est.)",
+  year =         "1931",
+  LCCN =         "DS149.E5 1931",
+  bibdate =      "Fri Oct 27 14:24:44 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated and edited with an introduction by Leon
+                 Simon.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  Calaprice-number = "170",
+  remark =       "This volume is composed of translations of extracts
+                 from speeches and letters delivered and written by
+                 Professor Einstein during the last nine or ten years
+                 [prior to publication].",
+  translator-dates = "1881--??",
+}
+
+@Book{Einstein:1931:CRO,
+  author =       "Albert Einstein",
+  title =        "Cosmic religion: with other opinions and aphorisms",
+  publisher =    "Covici-Friede",
+  address =      "New York, NY, USA",
+  pages =        "109",
+  year =         "1931",
+  LCCN =         "????",
+  bibdate =      "Fri Oct 27 19:09:07 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "166",
+}
+
+@Article{Einstein:1931:DC,
+  author =       "Albert Einstein",
+  title =        "The {1932 Disarmament Conference}",
+  journal =      j-NATION,
+  volume =       "133",
+  number =       "??",
+  pages =        "300--300",
+  year =         "1931",
+  ISSN =         "0027-8378",
+  bibdate =      "Sat Jul 17 09:20:38 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "169",
+  fjournal =     "The Nation",
+  journal-URL =  "http://catalog.hathitrust.org/api/volumes/oclc/1643268.html;
+                 http://www.ebscohost.com/archives/magazine-archives/the-nation",
+}
+
+@Article{Einstein:1931:DIA,
+  author =       "Albert Einstein",
+  title =        "Un discurso in{\'e}dito de {Alberto Einstein}.
+                 ({Spanish}) [{An} unpublished speech of {Albert
+                 Einstein}]",
+  journal =      "La Vida Literaria",
+  volume =       "III",
+  number =       "30",
+  pages =        "1--??",
+  month =        apr,
+  year =         "1931",
+  bibdate =      "Thu Jul 25 17:35:43 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "Spanish",
+}
+
+@Article{Einstein:1931:DIE,
+  author =       "Albert Einstein",
+  title =        "Un discurso in{\'e}dito de {Einstein}. ({Spanish})
+                 [{An} unpublished speech of {Einstein}]",
+  journal =      "Davar",
+  volume =       "61",
+  number =       "??",
+  pages =        "110--113",
+  month =        "????",
+  year =         "1931",
+  bibdate =      "Thu Jul 25 17:35:43 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "Spanish",
+}
+
+@Article{Einstein:1931:ETG,
+  author =       "Albert Einstein and Walter Mayer",
+  title =        "{Einheitliche Theorie von Gravitation und
+                 Elektrizit{\"a}t}. ({German}) [{Unified Theory of
+                 Gravitation and Electricity}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "541--557",
+  year =         "1931",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See part 2 \cite{Einstein:1932:ETG}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "172a",
+  language =     "German",
+  Whittaker-number = "159a",
+}
+
+@InCollection{Einstein:1931:F,
+  author =       "Albert Einstein",
+  editor =       "Sir Isaac Newton",
+  booktitle =    "Opticks, or, A treatise of the reflections,
+                 refractions, inflections \& colours of light",
+  title =        "Foreword",
+  publisher =    pub-MCGRAW-HILL,
+  address =      pub-MCGRAW-HILL:adr,
+  bookpages =    "xxviii + 2 + 414",
+  pages =        "??",
+  year =         "1931",
+  LCCN =         "QC353 .N57",
+  bibdate =      "Sat Jul 17 09:24:53 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Introduction by Prof. E. T. Whittaker.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "173",
+}
+
+@Article{Einstein:1931:KPA,
+  author =       "Albert Einstein",
+  title =        "{Zum Kosmologischen Problem der allgemeinen
+                 Relativit{\"a}tstheorie}. ({German}) [{On} the
+                 Cosmological Problem of the {General Theory of
+                 Relativity}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "235--237",
+  year =         "1931",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "171",
+  language =     "German",
+  remark =       "This paper retracts the cosmological constant
+                 introduced in \cite{Einstein:1917:KBA}, calling it his
+                 biggest blunder.",
+  Whittaker-number = "157",
+}
+
+@Article{Einstein:1931:KPF,
+  author =       "Albert Einstein and Richard C. Tolman and Boris
+                 Podolsky",
+  title =        "Knowledge of Past and Future in Quantum Mechanics",
+  journal =      j-PHYS-REV-2,
+  volume =       "37",
+  number =       "6",
+  pages =        "780--781",
+  month =        mar,
+  year =         "1931",
+  CODEN =        "PHRVAO",
+  DOI =          "http://dx.doi.org/10.1103/PhysRev.37.780",
+  ISSN =         "0031-899X (print), 1536-6065 (electronic)",
+  ISSN-L =       "0031-899X",
+  bibdate =      "Wed Nov 23 17:50:56 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://link.aps.org/abstract/PR/v37/p780;
+                 http://prola.aps.org/pdf/PR/v37/i6/p780_1",
+  acknowledgement = ack-nhfb,
+  Whittaker-number = "156",
+}
+
+@InCollection{Einstein:1931:MIE,
+  author =       "Albert Einstein",
+  editor =       "J. J. (Joseph John) Thomson",
+  booktitle =    "{James Clerk Maxwell}: A Commemoration Volume,
+                 1831--1931",
+  title =        "{Maxwell}'s Influence on the Evolution of the Idea of
+                 Physical Reality",
+  publisher =    pub-CAMBRIDGE,
+  address =      pub-CAMBRIDGE:adr,
+  bookpages =    "146",
+  pages =        "??--??",
+  year =         "1931",
+  LCCN =         "QC16.M4 J3",
+  bibdate =      "Fri Aug 13 09:41:16 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 library.ox.ac.uk:210/ADVANCE",
+  note =         "English translation in
+                 \cite[pp.~266--270]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+  editor-dates = "1856--1940",
+  subject =      "Maxwell, James Clerk",
+  subject-dates = "1831--1879",
+}
+
+@Article{Einstein:1931:MP,
+  author =       "Albert Einstein",
+  title =        "Militant Pacifism",
+  journal =      "World Tomorrow",
+  volume =       "14",
+  number =       "??",
+  pages =        "9--9",
+  year =         "1931",
+  bibdate =      "Sat Jul 17 09:15:08 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite{Einstein:1954:IO} as ``Active
+                 Pacifism''.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "165",
+}
+
+@Article{Einstein:1931:PGB,
+  author =       "A. Einstein",
+  title =        "{Physikalische Gesellschaft zu Berlin und Deutsche
+                 Gesellschaft f{\"u}r technische Physik. Berlin, 17.
+                 Juli 1931}. ({German}) [{Physical Society of Berlin and
+                 the German Society for Technical Physics, Berlin 17
+                 July 1931}]",
+  journal =      j-ANGEW-CHEM,
+  volume =       "44",
+  number =       "33",
+  pages =        "685--685",
+  day =          "15",
+  month =        aug,
+  year =         "1931",
+  CODEN =        "ANCEAD",
+  DOI =          "http://dx.doi.org/10.1002/ange.19310443305",
+  ISSN =         "1521-3757",
+  ISSN-L =       "0044-8249",
+  bibdate =      "Fri Jun 8 10:47:24 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Angewandte Chemie",
+  language =     "German",
+}
+
+@Book{Einstein:1931:RSGa,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: the {Special} and the {General Theory}",
+  publisher =    "Peter Smith",
+  address =      "New York, NY, USA",
+  pages =        "????",
+  year =         "1931",
+  bibdate =      "Wed Sep 28 06:21:25 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Authorized translation by Robert W. Lawson.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "174",
+}
+
+@Book{Einstein:1931:RSGb,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: the {Special} and the {General Theory},
+                 a Popular Exposition",
+  publisher =    pub-METHUEN,
+  address =      pub-METHUEN:adr,
+  edition =      "Tenth",
+  pages =        "xiii + 1 + 138",
+  year =         "1931",
+  bibdate =      "Wed Sep 28 06:21:25 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Authorized translation by Robert W. Lawson.",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1931:SH,
+  author =       "Albert Einstein",
+  title =        "Science and Happiness",
+  journal =      "Science (new series)",
+  volume =       "73",
+  number =       "1893",
+  pages =        "375--381",
+  day =          "10",
+  month =        apr,
+  year =         "1931",
+  bibdate =      "Sat Jul 17 09:13:20 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Speech given at the California Institute of
+                 Technology, and reprinted in the New York Times, 22
+                 February, 1931, section 9.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "164",
+}
+
+@Article{Einstein:1931:SUK,
+  author =       "Albert Einstein and Walter Mayer",
+  title =        "{Systematische Untersuchung {\"u}ber Kompatible
+                 Feldgleichungen welche in einem Riemannschen R{\"a}ume
+                 mit Fern-Parallelismus gesetzt werden k{\"o}nnen}.
+                 ({German}) [{Systematic} investigation of compatible
+                 field equations which can be set in a {Riemannian}
+                 space with remote parallelism]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "257--265",
+  year =         "1931",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  Whittaker-number = "158",
+}
+
+@Article{Freundlich:1931:NPF,
+  author =       "E. E. Freundlich and C. E. {St. John} and A.
+                 Einstein",
+  title =        "New proofs found of an {Einstein} idea: He is told
+                 findings show rays of star light bend in passing near
+                 sun",
+  journal =      j-NY-TIMES,
+  pages =        "3 (column 3)",
+  day =          "21",
+  month =        feb,
+  year =         "1931",
+  CODEN =        "NYTIAO",
+  ISSN =         "0362-4331 (print), 1542-667X, 1553-8095",
+  ISSN-L =       "0362-4331",
+  bibdate =      "Fri Oct 03 10:56:27 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "New York Times",
+  journal-URL =  "http://www.nytimes.com/",
+}
+
+@Article{Tagore:1931:NR,
+  author =       "Rabindranath Tagore and Albert Einstein",
+  title =        "The Nature of Reality",
+  journal =      "Modern Review (Calcutta)",
+  volume =       "49",
+  number =       "??",
+  pages =        "42--43",
+  year =         "1931",
+  bibdate =      "Sat Jul 17 09:19:14 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "168",
+  remark =       "Conversation about beauty and truth.",
+}
+
+@Article{Tagore:1931:TTE,
+  author =       "Rabindranath Tagore and Albert Einstein",
+  title =        "{Tagore} talks with {Einstein}",
+  journal =      "Asia",
+  volume =       "31",
+  number =       "??",
+  pages =        "138--142",
+  year =         "1931",
+  bibdate =      "Sat Jul 17 09:17:02 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "167",
+  remark =       "Conversation about eastern music.",
+}
+
+@Article{Einstein:1932:AN,
+  author =       "Albert Einstein",
+  title =        "To {American Negroes}",
+  journal =      "Crisis",
+  volume =       "39",
+  number =       "??",
+  pages =        "45--45",
+  year =         "1932",
+  bibdate =      "Sat Jul 17 10:28:22 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "175",
+}
+
+@Article{Einstein:1932:DBS,
+  author =       "Albert Einstein",
+  title =        "{Zu Dr. Berliners siebzigsten Geburtstag}. ({German})
+                 [{On Dr. Berliner}'s Seventieth Birthday]",
+  journal =      j-NATURWISSENSCHAFTEN,
+  volume =       "20",
+  number =       "??",
+  pages =        "913--913",
+  year =         "1932",
+  CODEN =        "NATWAY",
+  ISSN =         "0028-1042 (print), 1432-1904 (electronic)",
+  ISSN-L =       "0028-1042",
+  bibdate =      "Sat Jul 17 10:46:44 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "183",
+  language =     "German",
+  remark =       "Berliner was the editor of Die Naturwissenschaften.",
+}
+
+@Article{Einstein:1932:ETG,
+  author =       "Albert Einstein and Walter Mayer",
+  title =        "{Einheitliche Theorie von Gravitation und
+                 Elektrizit{\"a}t}. ({German}) [{Unified Theory of
+                 Gravitation and Electricity}]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "130--137",
+  year =         "1932",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See part 2 \cite{Einstein:1931:ETG}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "172b, 177",
+  language =     "German",
+  Whittaker-number = "159b",
+}
+
+@Article{Einstein:1932:GSR,
+  author =       "Albert Einstein",
+  title =        "{Gegenw{\"a}rter Stard der Relativit{\"a}tstheorie}.
+                 ({German}) [{Present} State of {Relativity Theory}]",
+  journal =      "Die Quelle",
+  volume =       "82",
+  number =       "??",
+  pages =        "440--442",
+  year =         "1932",
+  bibdate =      "Sat Jul 17 10:33:09 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "180",
+  language =     "German",
+  remark =       "Journal later renamed P{\"a}dagogischer F{\"u}hrer.",
+}
+
+@InCollection{Einstein:1932:IAS,
+  author =       "Albert Einstein",
+  booktitle =    "Builders of the Universe",
+  title =        "Introduction and Address to Students of {UCLA}",
+  publisher =    "US Library Association, Inc.",
+  address =      "Westwood Village, Los Angeles, CA, USA",
+  bookpages =    "96",
+  pages =        "??--??",
+  month =        feb,
+  year =         "1932",
+  LCCN =         "BD493 .B8",
+  bibdate =      "Sat Jul 17 10:44:28 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "182",
+}
+
+@InCollection{Einstein:1932:PES,
+  author =       "Albert Einstein and James Murphy",
+  editor =       "Max Planck",
+  booktitle =    "Where is Science Going?",
+  title =        "Prologue and Epilogue: a {Socratic} Dialogue",
+  publisher =    pub-NORTON,
+  address =      pub-NORTON:adr,
+  pages =        "??--??",
+  year =         "1932",
+  LCCN =         "Q175 .P57 1932",
+  bibdate =      "Sat Jul 17 10:35:41 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite{Einstein:1977:WSG}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "181",
+}
+
+@Article{Einstein:1932:RBE,
+  author =       "Albert Einstein and Willem de Sitter",
+  title =        "On the relation between the expansion and the mean
+                 density of the universe",
+  journal =      j-PROC-NATL-ACAD-SCI-USA,
+  volume =       "18",
+  number =       "3",
+  pages =        "213--214",
+  day =          "15",
+  month =        mar,
+  year =         "1932",
+  CODEN =        "PNASA6",
+  DOI =          "http://dx.doi.org/10.1073/pnas.18.3.213",
+  ISSN =         "0027-8424 (print), 1091-6490 (electronic)",
+  ISSN-L =       "0027-8424",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://www.pnas.org/cgi/reprint/18/3/213.pdf",
+  abbrjournal =  "Proc. Nat. Acad. Sci., Wash.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "179",
+  remark =       "The third paragraph of this article says:
+                 ``Historically the term containing the `cosmological
+                 constant' $ \lambda $ was introduced into the field
+                 equations in order to enable us to account
+                 theoretically for the existence of a finite mean
+                 density in a static universe. It now appears that in
+                 the dynamical case this end can be reached without the
+                 introduction of $ \lambda $.'' The authors used a
+                 lowercase Greek letter here, whereas its uppercase
+                 companion is more common. Einstein had introduced that
+                 constant into his field equations to permit a static
+                 universe, as he then believed it to be. Hubble's later
+                 experimental astronomical work gave clear evidence of
+                 an expanding universe (subsequently found to be not
+                 only expanding, but accelerating its expansion). Here,
+                 the authors admit that the cosmological constant is not
+                 needed.",
+  Whittaker-number = "160",
+}
+
+@Article{Einstein:1932:SVS,
+  author =       "Albert Einstein and Walter Mayer",
+  title =        "{Semi-Vektoren und Spinoren}. ({German})
+                 [{Semivectors} and spinors]",
+  journal =      j-S-B-PREUSS-AKAD-WISS-PHYS-MATH-KL,
+  volume =       "??",
+  number =       "??",
+  pages =        "523--550",
+  year =         "1932",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "178",
+  language =     "German",
+  Whittaker-number = "161",
+  xxnote =       "Calaprice has pages 522--550. Check!",
+}
+
+@Article{Einstein:1932:TJV,
+  author =       "Albert Einstein",
+  title =        "Is There a {Jewish} View of Life?",
+  journal =      "Opinion",
+  volume =       "2",
+  number =       "??",
+  pages =        "7--7",
+  day =          "26",
+  month =        sep,
+  year =         "1932",
+  bibdate =      "Sat Jul 17 10:29:04 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "176",
+}
+
+@Unpublished{Einstein:1933:CS,
+  author =       "Albert Einstein",
+  title =        "Civilization and Science",
+  day =          "4",
+  month =        oct,
+  year =         "1933",
+  bibdate =      "Sat Jul 17 11:03:19 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Speech given at Royal Albert Hall, London. Published
+                 in \cite{Einstein:1934:EDE}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "189a",
+}
+
+@Article{Einstein:1933:DAV,
+  author =       "Albert Einstein",
+  title =        "{Zur deutsch--amerikanischen Verst{\"a}ndigung}.
+                 ({German}) [{On German--American} agreement]",
+  journal =      "California Institute of Technology Bulletin",
+  volume =       "43",
+  number =       "138",
+  pages =        "4--8 (German), 9--12 (English)",
+  year =         "1933",
+  bibdate =      "Sat Jul 17 10:55:35 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reported in New York Times, January 24, 1933.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "186",
+  language =     "German",
+}
+
+@Article{Einstein:1933:DGS,
+  author =       "Albert Einstein and Walther Mayer",
+  booktitle =    "Proceedings 36",
+  title =        "{Dirac-Gleichung f{\"u}r Semi-Vektoren}. ({German})
+                 [{Dirac} Equations for Semivectors]",
+  journal =      "Proc. Acad. Sci. Amst.",
+  volume =       "36 (part 2)",
+  number =       "??",
+  publisher =    "Akademie van wetenschappen (Amsterdam)",
+  address =      "Amsterdam, The Netherlands",
+  pages =        "497--502",
+  year =         "1933",
+  bibdate =      "Sat Jul 17 11:06:04 2010",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/d/dirac-p-a-m.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "190",
+  language =     "German",
+}
+
+@InCollection{Einstein:1933:FAW,
+  author =       "Albert Einstein",
+  editor =       "Alfred Lief",
+  booktitle =    "The Fight against War",
+  title =        "The Fight against War",
+  publisher =    "John Day",
+  address =      "New York, NY, USA",
+  pages =        "64",
+  year =         "1933",
+  LCCN =         "????",
+  bibdate =      "Sat Jul 17 10:53:31 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "185",
+  remark =       "Selections of Einstein's writings and speeches
+                 (1914--1932).",
+}
+
+@Book{Einstein:1933:FTR,
+  author =       "Albert Einstein",
+  title =        "{Les Fondements de la Th{\'e}orie de la Relativit{\'e}
+                 G{\'e}n{\'e}rale}. ({French}) [{The} Foundation of the
+                 {Theory of General Relativity}]",
+  publisher =    "Hermann",
+  address =      "Paris, France",
+  pages =        "109",
+  year =         "1933",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 30 08:29:46 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated by M. Solovine.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+  Schilpp-number = "266",
+}
+
+@Article{Einstein:1933:LPA,
+  author =       "Albert Einstein",
+  title =        "Letter to the {Prussian Academy of Sciences}",
+  journal =      "Science (new series)",
+  volume =       "77",
+  number =       "??",
+  pages =        "444--444",
+  day =          "5",
+  month =        apr,
+  year =         "1933",
+  bibdate =      "Sat Jul 17 10:58:35 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "187",
+  remark =       "This letter explains the reasons for Einstein's
+                 resignation on March 28, 1933, from the Prussian
+                 Academy of Sciences.",
+}
+
+@Book{Einstein:1933:MTP,
+  author =       "Albert Einstein",
+  title =        "On the Method of Theoretical Physics",
+  publisher =    pub-CLARENDON,
+  address =      pub-CLARENDON:adr,
+  pages =        "15",
+  year =         "1933",
+  bibdate =      "Wed Dec 14 05:53:31 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "The Herbert Spencer Lecture, delivered at Oxford, 10
+                 June 1933. Reprinted in \cite{Einstein:1934:WSI}. New
+                 translation by Sonja Bargmann in
+                 \cite[270--276]{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "192",
+  Whittaker-number = "162",
+}
+
+@Book{Einstein:1933:NOG,
+  author =       "Albert Einstein",
+  title =        "Notes on the Origins of the {General Theory of
+                 Relativity}",
+  number =       "20",
+  publisher =    "Jackson",
+  address =      "Glasgow, Scotland",
+  pages =        "11",
+  year =         "1933",
+  LCCN =         "????",
+  bibdate =      "Sat Oct 28 11:50:16 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "The George A. Gibson lecture at Glasgow University,
+                 June 20, 1933. Reprinted in \cite{Einstein:1954:IO}.",
+  series =       "Glasgow University Publications",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "193",
+  Whittaker-number = "163",
+}
+
+@Article{Einstein:1933:SNF,
+  author =       "Albert Einstein and Walter Mayer",
+  title =        "{Spaltung der nat{\"u}rlichsten Feldgleichungen
+                 f{\"u}r Semi-Vektoren in Spinor-Gleichungen vom
+                 Diracschen Typus}. ({German}) [{Splitting} the most
+                 natural field equations for Semivectors into spinor
+                 equations of the {Dirac} type]",
+  journal =      "Proc. Acad. Sci. Amst.",
+  volume =       "36 (part 2)",
+  number =       "??",
+  publisher =    "Akademie van wetenschappen (Amsterdam)",
+  address =      "Amsterdam, The Netherlands",
+  pages =        "615--619",
+  year =         "1933",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/d/dirac-p-a-m.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "191",
+  language =     "German",
+  Whittaker-number = "164",
+}
+
+@Article{Einstein:1933:VM,
+  author =       "Albert Einstein",
+  title =        "Victim of Misunderstanding",
+  journal =      "Times (London)",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "16",
+  month =        sep,
+  year =         "1933",
+  bibdate =      "Sat Jul 17 11:00:58 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "188",
+}
+
+@TechReport{Einstein:1933:WKB,
+  author =       "Albert Einstein and Sigmund Freud",
+  title =        "{Warum Krieg? Ein Briefwechsel}. ({German}) [{Why}
+                 War? {A} Correspondence]",
+  institution =  "Institut International de Coop{\'e}ration
+                 Intellectuele",
+  year =         "1933",
+  bibdate =      "Wed Nov 23 11:47:12 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Misc{Einstein:1933:WW,
+  author =       "Albert Einstein",
+  title =        "Why War?",
+  howpublished = "Pamphlet from The International Institute of
+                 Intellectual Cooperation, League of Nations, Paris,
+                 France.",
+  year =         "1933",
+  bibdate =      "Sat Jul 17 10:50:26 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "184",
+  remark =       "Translated by Stuart Gilbert.",
+}
+
+@Book{Aynshtayn:1934:DOO,
+  author =       "Albert Aynshtayn",
+  title =        "D{\v{e}}mut {\^o}lami: ha-{\^o}lam k{\v{e}}fi e-h{\^u}
+                 mi{\d{s}}{\d{t}}ayyer l{\^\i}. ({Hebrew}) [{My} World
+                 View]",
+  publisher =    "{\v{S}}{\d{t}}{\=\i}bel",
+  address =      "Tel Aviv, Israel",
+  pages =        "224",
+  year =         "1934",
+  LCCN =         "????",
+  bibdate =      "Fri Jul 26 16:19:30 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Hebrew translation by {\v{S}}. E{\d{t}}{\^\i}nger of
+                 \cite{Einstein:1934:MWGa}.",
+  acknowledgement = ack-nhfb,
+  language =     "Hebrew",
+}
+
+@Book{Einstein:1934:CJV,
+  author =       "Albert Einstein",
+  title =        "Comment je vois le monde. ({French}) [{My} World
+                 View]",
+  publisher =    "Ernst Flammarion",
+  address =      "Paris, France",
+  pages =        "vi + 258",
+  year =         "1934",
+  LCCN =         "????",
+  bibdate =      "Fri Jul 26 16:14:46 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "French translation by Georges Cros of
+                 \cite{Einstein:1934:MWGa}.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Article{Einstein:1934:DSV,
+  author =       "Albert Einstein and Walter Mayer",
+  title =        "{Darstellung der Semi-Vektoren als gew{\"o}hnliche
+                 Vektoren von besonderem Differentiationscharakter}.
+                 ({German}) [{Representation} of the semivectors as
+                 ordinary vectors of a special differentiation
+                 character]",
+  journal =      j-ANN-MATH-2,
+  volume =       "35",
+  number =       "1",
+  pages =        "104--110",
+  month =        jan,
+  year =         "1934",
+  CODEN =        "ANMAAH",
+  ISSN =         "0003-486X (print), 1939-8980 (electronic)",
+  ISSN-L =       "0003-486X",
+  MRnumber =     "MR1503145",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "2-T;
+                 http://links.jstor.org/sici?sici=0003-486X(193401)2:35:1<104:DDSAGV>2.0.CO",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "196",
+  fjournal =     "Annals of Mathematics. Second Series",
+  language =     "German",
+  Whittaker-number = "165",
+}
+
+@Article{Einstein:1934:EDE,
+  author =       "Albert Einstein",
+  title =        "{Europe}'s Danger, {Europe}'s Hope",
+  journal =      "Friends of Europe Publications",
+  volume =       "4",
+  pages =        "??--??",
+  year =         "1934",
+  bibdate =      "Sat Jul 17 11:02:35 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprint of speech \cite{Einstein:1933:CS}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "189b",
+}
+
+@Book{Einstein:1934:ES,
+  author =       "Albert Einstein",
+  title =        "Essays in Science",
+  publisher =    pub-PHILOSOPHICAL-LIBRARY,
+  address =      pub-PHILOSOPHICAL-LIBRARY:adr,
+  pages =        "xi + 114",
+  year =         "1934",
+  LCCN =         "????",
+  bibdate =      "Sat Sep 24 13:29:10 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Selected essays from Mein Weltbild, translated by Alan
+                 Harris.",
+  subject =      "Physics; Science; Philosophy; Peace; Social aspects",
+}
+
+@Article{Einstein:1934:EWP,
+  author =       "Albert Einstein",
+  title =        "Education and World Peace",
+  journal =      "Progressive Education",
+  volume =       "11",
+  number =       "??",
+  pages =        "440--440",
+  year =         "1934",
+  bibdate =      "Sat Jul 17 11:15:05 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "195",
+}
+
+@Book{Einstein:1934:GEF,
+  author =       "Albert Einstein",
+  title =        "La {G}{\'e}om{\'e}trie et l'Exp{\'e}rience. ({French})
+                 [{Geometry} and Experience]",
+  publisher =    pub-GAUTHIER-VILLARS,
+  address =      pub-GAUTHIER-VILLARS:adr,
+  pages =        "24",
+  year =         "1934",
+  bibdate =      "Thu Apr 12 18:37:50 2007",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "French translation by Maurice Solovine.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@InCollection{Einstein:1934:I,
+  author =       "Albert Einstein",
+  booktitle =    "The World in Modern Science",
+  title =        "Introduction",
+  publisher =    pub-GOLLANCZ,
+  address =      pub-GOLLANCZ:adr,
+  pages =        "??--??",
+  year =         "1934",
+  LCCN =         "????",
+  bibdate =      "Sat Jul 17 11:19:44 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "197",
+  language =     "German and English",
+}
+
+@Article{Einstein:1934:MTP,
+  author =       "Albert Einstein",
+  title =        "On the Method of Theoretical Physics",
+  journal =      j-PHILOS-SCI,
+  volume =       "1",
+  number =       "2",
+  pages =        "163--169",
+  month =        apr,
+  year =         "1934",
+  CODEN =        "PHSCA6",
+  ISSN =         "0031-8248 (print), 1539-767X (electronic)",
+  ISSN-L =       "0031-8248",
+  bibdate =      "Sat Mar 1 08:04:22 MST 2014",
+  bibsource =    "http://www.jstor.org/action/showPublication?journalCode=philscie;
+                 http://www.jstor.org/stable/i209569;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 http://www.math.utah.edu/pub/tex/bib/philossci1930.bib",
+  URL =          "http://www.jstor.org/stable/184387",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Philosophy of Science",
+  journal-URL =  "http://www.jstor.org/journals/00318248.html",
+  remark =       "This paper is based on Einstein's Herbert Spencer
+                 Lecture at Oxford University (10 June 1933). It
+                 contains the text ``It can scarcely be denied that the
+                 supreme goal of all theory is to make the irreducible
+                 basic elements as simple and as few as possible without
+                 having to surrender the adequate representation of a
+                 single datum of experience.''. That text is sometimes
+                 rephrased as ``Everything should be made as simple as
+                 possible, but not simpler'' and attributed to
+                 Einstein.",
+}
+
+@Book{Einstein:1934:MWGa,
+  author =       "Albert Einstein",
+  booktitle =    "{Mein Weltbild}. ({German}) [{My} World View]",
+  title =        "{Mein Weltbild}. ({German}) [{My} World View]",
+  publisher =    "Querido Verlag",
+  address =      "Amsterdam, The Netherlands",
+  pages =        "269",
+  year =         "1934",
+  LCCN =         "????",
+  bibdate =      "Fri Jul 26 16:14:46 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Book{Einstein:1934:MWGb,
+  author =       "Albert Einstein",
+  title =        "{Mein Weltbild}. ({Dutch}) [{My} World View]",
+  publisher =    "Van Holkema \& Warendorf",
+  address =      "Amsterdam, The Netherlands",
+  pages =        "284",
+  year =         "1934",
+  LCCN =         "????",
+  bibdate =      "Fri Jul 26 16:14:46 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Dutch translation by T. Landr{\'e} of
+                 \cite{Einstein:1934:MWGa}.",
+  acknowledgement = ack-nhfb,
+  language =     "Dutch",
+}
+
+@InCollection{Einstein:1934:NOG,
+  author =       "Albert Einstein",
+  title =        "Notes on the Origin of the {General Theory of
+                 Relativity}",
+  crossref =     "Einstein:1934:MWGa",
+  pages =        "??--??",
+  year =         "1934",
+  bibdate =      "Fri Aug 13 09:47:21 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in \cite[pp.
+                 78--84]{Einstein:1934:ES} and \cite[pp.
+                 285--290]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+  remark =       "See comments in \cite[page 96]{Miller:1999:EFS} about
+                 Einstein's awareness (or lack thereof) in 1907 of the
+                 important work of Roland von E{\"o}tv{\"o}s in
+                 1888--1889 \cite{vonEotvos:1890:FVK,Eotvos:1891:AEV}
+                 that demonstrated the equivalence of gravitational and
+                 inertial mass to about one part in a $ 10^9 $. Miller
+                 dates the experiments in 1891, but that is incorrect,
+                 because they were reported in a paper read before the
+                 Academy on 20 January 1889. See also the comments in
+                 the English translation \cite{Eotvos:2008:GPE}.",
+}
+
+@InCollection{Einstein:1934:NPE,
+  author =       "Albert Einstein",
+  booktitle =    "Almanak van het {Leidsche} Studencorps",
+  title =        "{Nachruf f{\"u}r Paul Ehrenfest}. ({German})
+                 [{Obituary} for {Paul Ehrenfest}]",
+  publisher =    "Doesburg",
+  address =      "Leiden, The Netherlands",
+  pages =        "??--??",
+  year =         "1934",
+  bibdate =      "Sat Jul 17 11:17:48 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "198",
+  language =     "German",
+}
+
+@InCollection{Einstein:1934:PSE,
+  author =       "Albert Einstein",
+  title =        "The Problem of Space, Ether, and the Field in
+                 Physics",
+  crossref =     "Einstein:1934:MWGa",
+  pages =        "??--??",
+  year =         "1934",
+  bibdate =      "Fri Aug 13 09:47:21 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation in
+                 \cite[pp.~276--285]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1934:SCD,
+  editor =       "Albert Einstein",
+  booktitle =    "{Sinfonia concertante A dur, f{\"u}r Violine und
+                 Violoncello mit Orchester [von Johann Christian Bach
+                 1735--1782]}",
+  title =        "{Sinfonia concertante A dur, f{\"u}r Violine und
+                 Violoncello mit Orchester [von Johann Christian Bach
+                 1735--1782]}",
+  publisher =    "Ernst Eulenburg",
+  address =      "Leipzig, Germany",
+  pages =        "38",
+  year =         "1934",
+  LCCN =         "????",
+  bibdate =      "Fri Aug 21 10:38:36 2015",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1934:WSI,
+  author =       "Albert Einstein",
+  title =        "The world as {I} see it",
+  publisher =    "Covici-Friede",
+  address =      "New York, NY, USA",
+  pages =        "????",
+  year =         "1934",
+  LCCN =         "AC35 .E52",
+  bibdate =      "Mon Oct 9 19:00:51 MDT 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  note =         "Translated by Alan Harris.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Physics; Addresses, essays, lectures; Jews; Peace",
+}
+
+@Article{Einstein:1935:AJU,
+  author =       "Albert Einstein",
+  title =        "Appeal for {Jewish} Unity",
+  journal =      "New Palestine",
+  volume =       "25",
+  number =       "9",
+  pages =        "1--1",
+  year =         "1935",
+  bibdate =      "Sat Jul 17 11:20:59 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "199",
+}
+
+@Article{Einstein:1935:CQM,
+  author =       "Albert Einstein and Boris Podolsky and Nathan Rosen",
+  title =        "Can quantum mechanical description of physical reality
+                 be considered complete?",
+  journal =      j-PHYS-REV-2,
+  volume =       "47",
+  number =       "10",
+  pages =        "777--780",
+  day =          "15",
+  month =        may,
+  year =         "1935",
+  CODEN =        "PHRVAO",
+  DOI =          "http://dx.doi.org/10.1103/PhysRev.47.777",
+  ISSN =         "0031-899X (print), 1536-6065 (electronic)",
+  ISSN-L =       "0031-899X",
+  bibdate =      "Wed Nov 23 11:34:49 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://prola.aps.org/abstract/PR/v47/i10/p777_1",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "201",
+  remark =       "According to APS News Online {\tt
+                 http://www.aps.org/apsnews/0605/060505.cfm}, this paper
+                 is still the most downloaded publication from the APS
+                 journal archives, 80 years after it was written,",
+  Whittaker-number = "167",
+}
+
+@Article{Einstein:1935:EDE,
+  author =       "Albert Einstein",
+  title =        "Elementary derivation of the equivalence of mass and
+                 energy",
+  journal =      j-BULL-AMS,
+  volume =       "41",
+  number =       "??",
+  pages =        "223--230",
+  year =         "1935",
+  CODEN =        "BAMOAD",
+  ISSN =         "0002-9904 (print), 1936-881X (electronic)",
+  ISSN-L =       "0002-9904",
+  MRnumber =     "61.0852.02",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "J. W. Gibbs Lecture to the American Association for
+                 the Advancement of Science (AAAS), 28 December 1934.
+                 Reprinted in \cite{Einstein:2000:EDE}.",
+  URL =          "http://www.ams.org/bull/2000-37-01/S0273-0979-99-00805-8/S0273-0979-99-00805-8.pdf",
+  ZMnumber =     "Zbl 0011.28108",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "203",
+  Whittaker-number = "166",
+}
+
+@Book{Einstein:1935:MOS,
+  author =       "Albert Einstein",
+  title =        "M{\'o}j obraz {\'s}wiata. (Polish) [{My} World View]",
+  publisher =    "M. Fruchtman",
+  address =      "Warszawa, Poland",
+  pages =        "283 + 4",
+  year =         "1935",
+  LCCN =         "????",
+  bibdate =      "Fri Jul 26 16:09:49 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Polish translation by S. {\L}ukowski of
+                 \cite{Einstein:1934:MWGa}.",
+  acknowledgement = ack-nhfb,
+  language =     "Polish",
+}
+
+@Book{Einstein:1935:MR,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "????",
+  year =         "1935",
+  LCCN =         "????",
+  bibdate =      "Wed Nov 23 11:36:21 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1935:MW,
+  author =       "Albert Einstein",
+  title =        "{Mein Weltbild}",
+  publisher =    "Wisdom Library",
+  address =      "New York, NY",
+  pages =        "xiii + 112",
+  year =         "1935",
+  LCCN =         "????",
+  bibdate =      "Fri Jul 26 16:25:56 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation by Alan Harris of
+                 \cite{Einstein:1934:MWGa}.",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1935:PMW,
+  author =       "Albert Einstein",
+  title =        "Peace Must be Waged: Interview by {R. M. Bartlett}",
+  journal =      "Survey Graphic",
+  volume =       "24",
+  number =       "??",
+  pages =        "384--384",
+  year =         "1935",
+  bibdate =      "Sat Jul 17 11:22:06 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "200",
+}
+
+@Article{Einstein:1935:PPG,
+  author =       "A. Einstein and N. Rosen",
+  title =        "The Particle Problem in the {General Theory of
+                 Relativity}",
+  journal =      j-PHYS-REV-2,
+  volume =       "48",
+  number =       "1",
+  pages =        "73--77",
+  month =        jul,
+  year =         "1935",
+  CODEN =        "PHRVAO",
+  DOI =          "http://dx.doi.org/10.1103/PhysRev.48.73",
+  ISSN =         "0031-899X (print), 1536-6065 (electronic)",
+  ISSN-L =       "0031-899X",
+  bibdate =      "Wed Nov 23 18:01:14 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://link.aps.org/abstract/PR/v48/p73",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "202",
+  Whittaker-number = "168",
+}
+
+@Misc{Einstein:1936:DIA,
+  author =       "Albert Einstein",
+  title =        "Declaration of Intention for {Albert Einstein}",
+  howpublished = "Web document",
+  day =          "15",
+  month =        jan,
+  year =         "1936",
+  bibdate =      "Mon Mar 10 10:15:23 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://hdl.loc.gov/loc.wdl/dna.2745;
+                 http://www.wdl.org/en/item/2745",
+  acknowledgement = ack-nhfb,
+  remark =       "From the World Digital Library document archive. This
+                 is Einstein's declaration seeking US citizenship; he
+                 achieved that status in 1940.",
+}
+
+@Article{Einstein:1936:FL,
+  author =       "Albert Einstein",
+  title =        "Freedom of Learning",
+  journal =      "Science (new series)",
+  volume =       "83",
+  number =       "??",
+  pages =        "372--373",
+  year =         "1936",
+  bibdate =      "Sat Jul 17 11:27:58 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "205",
+}
+
+@Article{Einstein:1936:LLA,
+  author =       "Albert Einstein",
+  title =        "Lens-like action of a star by deviation of light in
+                 the gravitational field",
+  journal =      j-SCIENCE,
+  volume =       "84",
+  number =       "??",
+  pages =        "506--507",
+  year =         "1936",
+  CODEN =        "SCIEAS",
+  ISSN =         "0036-8075 (print), 1095-9203 (electronic)",
+  ISSN-L =       "0036-8075",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See postscript \cite{Renn:1997:OGL}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "208",
+  journal-URL =  "http://www.sciencemag.org/archive/",
+  remark =       "In this paper, Einstein describes some calculations
+                 that he had done in 1912 that predicted that the
+                 gravity of a large star could act like a lens, bending,
+                 and magnifying, light from a star behind it. He felt
+                 that there was no hope of observing such lensing,
+                 because it was beyond the resolving power of
+                 astronomical instruments of the time.\par
+
+                 However, in 1979, exactly such an effect was first
+                 found with a quasar, and since then, many more examples
+                 of gravitational lenses have been discovered. See
+                 \cite{Bennett:2005:AOL} for a review, \cite[Chapter
+                 70]{Bartusiak:2006:AUD} for details and references to
+                 the original papers, \cite{Bennett:2005:AOL} for a
+                 review, and \cite{Gates:2009:ETH} for a book-length
+                 treatment.\par
+
+                 The powerful lensing from massive objects, such as
+                 neutron stars and galaxies, allows determination of the
+                 masses of those objects (according to a prediction in
+                 1937 by the Swiss astronomer Fritz Zwicky
+                 \cite{Zwicky:1937:MNC}) at Caltech, and that in turn
+                 led to the discovery of dark matter, and the
+                 observation that it makes up about 90\% of the mass of
+                 the universe.",
+  Whittaker-number = "171",
+}
+
+@Article{Einstein:1936:PR,
+  author =       "A. Einstein",
+  title =        "Physics and Reality",
+  journal =      j-J-FRANKLIN-INST,
+  volume =       "221",
+  number =       "3",
+  pages =        "349--382",
+  month =        mar,
+  year =         "1936",
+  CODEN =        "JFINAB",
+  DOI =          "http://dx.doi.org/10.1016/S0016-0032(36)91047-5",
+  ISSN =         "0016-0032 (print), 1879-2693 (electronic)",
+  ISSN-L =       "0016-0032",
+  bibdate =      "Wed Dec 14 05:58:39 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite[290--323]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+  Whittaker-number = "169b",
+}
+
+@Article{Einstein:1936:PRG,
+  author =       "A. Einstein",
+  title =        "{Physik und Realit{\"a}t}. ({German}) [{Physics} and
+                 Reality]",
+  journal =      j-J-FRANKLIN-INST,
+  volume =       "221",
+  number =       "3",
+  pages =        "313--347",
+  month =        mar,
+  year =         "1936",
+  CODEN =        "JFINAB",
+  DOI =          "http://dx.doi.org/10.1016/S0016-0032(36)91045-1",
+  ISSN =         "0016-0032 (print), 1879-2693 (electronic)",
+  ISSN-L =       "0016-0032",
+  bibdate =      "Wed Dec 14 05:58:39 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite{Einstein:1954:IO}. English
+                 translation in \cite{Einstein:1936:PR}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "206",
+  language =     "German",
+  Whittaker-number = "169a",
+}
+
+@Book{Einstein:1936:RSG,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: the {Special} and the {General Theory}:
+                 a popular exposition",
+  publisher =    pub-METHUEN,
+  address =      pub-METHUEN:adr,
+  edition =      "Eleventh",
+  pages =        "xiii + 138",
+  year =         "1936",
+  bibdate =      "Wed Sep 28 06:21:25 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Authorized translation by Robert W. Lawson.",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1936:STC,
+  author =       "Albert Einstein",
+  title =        "Some Thoughts Concerning Education",
+  journal =      "School and Society",
+  volume =       "44",
+  number =       "??",
+  pages =        "589--592",
+  year =         "1936",
+  bibdate =      "Sat Jul 17 11:25:59 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated by Linda Arronet. Reprinted in
+                 \cite{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "204",
+}
+
+@Article{Einstein:1936:TBP,
+  author =       "A. Einstein and N. Rosen",
+  title =        "Two-Body Problem in {General Relativity Theory}",
+  journal =      j-PHYS-REV,
+  volume =       "49",
+  number =       "5",
+  pages =        "404--405",
+  day =          "1",
+  month =        mar,
+  year =         "1936",
+  CODEN =        "PHRVAO",
+  DOI =          "http://dx.doi.org/10.1103/PhysRev.49.404.2",
+  ISSN =         "0031-899X (print), 1536-6065 (electronic)",
+  ISSN-L =       "0031-899X",
+  bibdate =      "Wed Nov 23 17:59:28 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://link.aps.org/abstract/PR/v49/p404/s2",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "207",
+  remark =       "This paper introduces what is known as the
+                 ``Einstein--Rosen bridge'', now commonly called a
+                 ``wormhole''.",
+  Whittaker-number = "170",
+}
+
+@Book{Eistein:1937:CJV,
+  author =       "Albert Eistein",
+  title =        "Comment je vois le monde. ({French}) [{How} {I} see
+                 the world]",
+  publisher =    "Flammarion",
+  address =      "Paris, France",
+  pages =        "vi + 254",
+  year =         "1937",
+  LCCN =         "????",
+  bibdate =      "Fri Aug 21 08:56:56 MDT 2015",
+  bibsource =    "fsz3950.oclc.org:210/WorldCat;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Article{Einstein:1937:GW,
+  author =       "A. Einstein and N. Rosen",
+  title =        "On gravitational waves",
+  journal =      j-J-FRANKLIN-INST,
+  volume =       "223",
+  number =       "1",
+  pages =        "43--54",
+  month =        jan,
+  year =         "1937",
+  CODEN =        "JFINAB",
+  DOI =          "http://dx.doi.org/10.1016/S0016-0032(37)90583-0",
+  ISSN =         "0016-0032 (print), 1879-2693 (electronic)",
+  ISSN-L =       "0016-0032",
+  bibdate =      "Wed Dec 14 09:32:54 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  abstract =     "The rigorous solution for cylindrical gravitational
+                 waves is given. For the convenience of the reader the
+                 theory of gravitational waves and their production,
+                 already known in principle, is given in the first part
+                 of this paper. After encountering relationships which
+                 cast doubt on the existence of rigorous solutions for
+                 undulatory gravitational fields, we investigate
+                 rigorously the case of cylindrical gravitational waves.
+                 It turns out that rigorous solutions exist and that the
+                 problem reduces to the usual cylindrical waves in
+                 euclidean space.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "209",
+  remark =       "According to \cite[page 9]{Schweber:2008:EOM}, this
+                 paper was originally submitted to the Physical Review
+                 with the title ``Do gravitational waves exist?'' [and a
+                 conclusion that they cannot exist], but withdrawn in
+                 anger by Einstein when he found that it had been sent
+                 to outside reviewers. He was accustomed to having his
+                 papers published in journals after only editorial
+                 approval. Except for a brief note much later
+                 \cite{Einstein:1953:CCU}, he never again submitted a
+                 paper to the Physical Review. However, Einstein did
+                 respond to reviewer comments, and revised the paper
+                 before it was published in the journal of this entry.
+                 See \cite{Kennefick:2005:EVP} for more on the story.",
+  Whittaker-number = "172",
+}
+
+@Book{Einstein:1938:EP,
+  author =       "Albert Einstein and Leopold Infeld",
+  title =        "The evolution of physics",
+  publisher =    pub-CAMBRIDGE,
+  address =      pub-CAMBRIDGE:adr,
+  pages =        "319",
+  year =         "1938",
+  LCCN =         "QC 7 EIN",
+  bibdate =      "Sat Sep 24 13:50:00 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 innopac.wits.ac.za:210/INNOPAC",
+  series =       "Cambridge library of modern science.",
+  acknowledgement = ack-nhfb,
+  author-dates = "Albert Einstein (1879--1955); Leopold Infeld
+                 (1898--1968)",
+  subject =      "Physics; History; Relativity (Physics); Quantum
+                 theory",
+}
+
+@Book{Einstein:1938:EPG,
+  author =       "Albert Einstein and Leopold Infeld",
+  title =        "The evolution of physics: the growth of ideas from
+                 early concepts to {Relativity} and quanta",
+  publisher =    pub-SIMON-SCHUSTER,
+  address =      pub-SIMON-SCHUSTER:adr,
+  pages =        "x + 319 + 1",
+  year =         "1938",
+  LCCN =         "QC7 .E5",
+  bibdate =      "Mon Oct 9 06:48:08 MDT 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+  author-dates = "Albert Einstein (1879--1955); Leopold Infeld
+                 (1898--1968)",
+  Calaprice-number = "214",
+  subject =      "physics; history; Relativity (physics); quantum
+                 theory",
+  Whittaker-number = "173",
+}
+
+@Article{Einstein:1938:GEPa,
+  author =       "Albert Einstein and Leon Infeld and Banesh Hoffmann",
+  title =        "The gravitational equations and the problem of
+                 motion",
+  journal =      j-ANN-MATH-2,
+  volume =       "39",
+  number =       "1",
+  pages =        "65--100",
+  month =        jan,
+  year =         "1938",
+  CODEN =        "ANMAAH",
+  ISSN =         "0003-486X (print), 1939-8980 (electronic)",
+  ISSN-L =       "0003-486X",
+  MRnumber =     "MR1503389",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "2-P;
+                 http://links.jstor.org/sici?sici=0003-486X(193801)2:39:1<65:TGEATP>2.0.CO",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "212",
+  fjournal =     "Annals of Mathematics. Second Series",
+  received =     "16 June 1937",
+  Whittaker-number = "174a",
+  xxtitle =      "Gravitational Equations and the Problems of
+                 Relativity",
+}
+
+@Article{Einstein:1938:GEPb,
+  author =       "Albert Einstein and Leon Infeld and Banesh Hoffmann",
+  title =        "The gravitational equations and the problems of
+                 motion",
+  journal =      j-ANN-MATH-2,
+  volume =       "41",
+  number =       "2",
+  pages =        "455--564",
+  month =        jan,
+  year =         "1938",
+  CODEN =        "ANMAAH",
+  ISSN =         "0003-486X (print), 1939-8980 (electronic)",
+  ISSN-L =       "0003-486X",
+  MRnumber =     "MR1503389",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "2-P;
+                 http://links.jstor.org/sici?sici=0003-486X(193801)2:39:1<65:TGEATP>2.0.CO",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Annals of Mathematics. Second Series",
+  Whittaker-number = "174b",
+}
+
+@Article{Einstein:1938:GKT,
+  author =       "Albert Einstein and Peter Bergmann",
+  title =        "On a generalization of {Kaluza}'s theory of
+                 electricity",
+  journal =      j-ANN-MATH-2,
+  volume =       "39",
+  number =       "3",
+  pages =        "683--701",
+  month =        jul,
+  year =         "1938",
+  CODEN =        "ANMAAH",
+  ISSN =         "0003-486X (print), 1939-8980 (electronic)",
+  ISSN-L =       "0003-486X",
+  MRnumber =     "MR1503432",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "2-9;
+                 http://links.jstor.org/sici?sici=0003-486X(193807)2:39:3<683:OAGOKT>2.0.CO",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "213",
+  fjournal =     "Annals of Mathematics. Second Series",
+  Whittaker-number = "175",
+}
+
+@Article{Einstein:1938:ODZ,
+  author =       "Albert Einstein",
+  title =        "Our Debt to {Zionism}",
+  journal =      "New Palestine",
+  volume =       "28",
+  number =       "2",
+  pages =        "2--4",
+  day =          "2",
+  month =        apr,
+  year =         "1938",
+  bibdate =      "Sat Jul 17 11:31:14 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Address to National Labor Committee for Palestine on
+                 17 April 1938. Reprinted in \cite{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "210",
+}
+
+@Book{Einstein:1938:PAE,
+  author =       "Albert Einstein and Leopold Infeld",
+  title =        "{Physik als Abenteuer der Erkenntnis}. ({German})
+                 [{Physics} as adventures of the realization]",
+  publisher =    "Sijthoff's Uitgeversmaatschappij",
+  address =      "Leiden, The Netherlands",
+  pages =        "viii + 222",
+  year =         "1938",
+  LCCN =         "????",
+  bibdate =      "Fri Nov 25 12:11:52 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://bouquin.de/ch/88335.php",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1938:WDT,
+  author =       "Albert Einstein",
+  title =        "Why Do They Hate the {Jews}?",
+  journal =      "Collier's Weekly",
+  volume =       "102",
+  number =       "??",
+  pages =        "9--10, 38",
+  day =          "26",
+  month =        nov,
+  year =         "1938",
+  bibdate =      "Sat Jul 17 11:33:07 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated by Ruth Norden. Reprinted in
+                 \cite{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "211",
+}
+
+@Misc{Einstein:1939:AEL,
+  author =       "Albert Einstein",
+  title =        "{Albert Einstein}'s Letter to {President Franklin
+                 Delano Roosevelt}",
+  howpublished = "World-Wide Web document",
+  day =          "2",
+  month =        aug,
+  year =         "1939",
+  bibdate =      "Mon Jun 18 17:52:21 2012",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/f/fermi-enrico.bib;
+                 http://www.math.utah.edu/pub/bibnet/authors/s/szilard-leo.bib;
+                 http://www.math.utah.edu/pub/bibnet/authors/t/teller-edward.bib;
+                 http://www.math.utah.edu/pub/bibnet/authors/w/wigner-eugene.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite{Einstein:1963:EL}.",
+  URL =          "http://hypertextbook.com/eworld/einstein.shtml;
+                 http://www.anl.gov/Science_and_Technology/History/Anniversary_Frontiers/aetofdr.html;
+                 http://www.lanl.gov/history/road/pdf/Einstein.pdf",
+  acknowledgement = ack-nhfb,
+  remark =       "The letter, written at the urging of Leo Szilard,
+                 Eugene Wigner, and Edward Teller, begins: ``Some recent
+                 work by E. Fermi and L. Szilard, which has been
+                 communicated to me in manuscript, leads me to expect
+                 that the element uranium may be turned into a new and
+                 important source of energy in the immediate future.''",
+  remark-2 =     "Reprinted in \cite[pages 113--114]{Segre:1970:EFPb}.",
+}
+
+@Article{Einstein:1939:EWB,
+  author =       "Albert Einstein",
+  title =        "{Europe} Will Become a Barren Waste",
+  journal =      "New Palestine",
+  volume =       "29",
+  number =       "??",
+  pages =        "1--2",
+  day =          "24",
+  month =        mar,
+  year =         "1939",
+  bibdate =      "Sat Jul 17 11:41:22 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "217",
+}
+
+@Unpublished{Einstein:1939:NRG,
+  author =       "Albert Einstein",
+  title =        "{Naturwissenschaft und Religion}. ({German})
+                 [{Science} and Religion]",
+  day =          "19",
+  month =        may,
+  year =         "1939",
+  bibdate =      "Fri Jul 26 15:58:13 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Address delivered at the Princeton Theological
+                 Seminary. Reprinted in \cite[pages
+                 25--29]{Einstein:1952:MSJ}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Unpublished{Einstein:1939:OG,
+  author =       "Albert Einstein",
+  title =        "Our Goal",
+  year =         "1939",
+  bibdate =      "Sat Jul 17 11:37:27 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Mimeographed address at a conference at the Princeton
+                 Theological Seminary, 19 May 1939. Reprinted in
+                 \cite[pages 41--44]{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "215",
+  remark =       "See \cite{????} for part 2.",
+}
+
+@Article{Einstein:1939:SBS,
+  author =       "Albert Einstein",
+  title =        "Sixtieth Birthday Statement",
+  journal =      "Science (new series)",
+  volume =       "89",
+  number =       "??",
+  pages =        "242--242",
+  year =         "1939",
+  bibdate =      "Sat Jul 17 11:40:31 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "216",
+}
+
+@Article{Einstein:1939:SSS,
+  author =       "Albert Einstein",
+  title =        "On a stationary system with spherical symmetry
+                 consisting of many gravitating masses",
+  journal =      j-ANN-MATH-2,
+  volume =       "40",
+  number =       "4",
+  pages =        "922--936",
+  month =        oct,
+  year =         "1939",
+  CODEN =        "ANMAAH",
+  ISSN =         "0003-486X (print), 1939-8980 (electronic)",
+  ISSN-L =       "0003-486X",
+  MRclass =      "70.1X",
+  MRnumber =     "MR0000363 (1,61a)",
+  MRreviewer =   "H. P. Robertson",
+  bibdate =      "Fri Nov 25 11:15:57 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "2-E;
+                 http://links.jstor.org/sici?sici=0003-486X(193910)2:40:4<922:OASSWS>2.0.CO",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "218",
+  fjournal =     "Annals of Mathematics. Second Series",
+  remark =       "This paper attempts to prove the impossibility of
+                 forming black holes. See the discussion in
+                 \cite[page~346]{Bartusiak:2006:AUD} and
+                 \cite[page~80]{Bernstein:1996:RFB}.
+
+                 The last page of Einstein's article summarizes the
+                 results of his computations:\par
+
+                 ``The essential result of this investigation is a clear
+                 understanding as to why the `Schwarzschild
+                 singularities' do not exist in physical reality.
+                 Although the theory given here treats only clusters
+                 whose particles move along circular paths it does not
+                 seem to be subject to reasonable doubt that more
+                 general cases will have analogous results. The
+                 `Schwarzschild singularity' does not appear for the
+                 reason that matter cannot be concentrated arbitrarily.
+                 And this is due to the fact that otherwise the
+                 constituting particles would reach the velocity of
+                 light.\par
+
+                 This investigation arose out of discussions the author
+                 conducted with Professor H. P. Robertson and with Drs.
+                 V. Bargmann and P. Bergmann on the mathematical and
+                 physical significance of the Schwarzschild singularity.
+                 The problem quite naturally leads to the question,
+                 answered by this paper in the negative, as to whether
+                 physical models are capable of exhibiting such a
+                 singularity.''",
+  Whittaker-number = "176",
+}
+
+@Article{Einstein:1940:CCF,
+  author =       "Albert Einstein",
+  title =        "Considerations concerning the fundamentals of
+                 theoretical physics",
+  journal =      j-SCIENCE,
+  volume =       "91",
+  number =       "??",
+  pages =        "487--492",
+  day =          "24",
+  month =        may,
+  year =         "1940",
+  CODEN =        "SCIEAS",
+  ISSN =         "0036-8075 (print), 1095-9203 (electronic)",
+  ISSN-L =       "0036-8075",
+  bibdate =      "Sat Oct 28 08:28:24 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Address for the Eighth American Scientific Congress,
+                 Washington, DC, May 24, 1940. Reprinted in
+                 \cite[pp.~323--335]{Einstein:1982:IO} as ``The
+                 Fundaments of Theoretical Physics''.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "224",
+  journal-URL =  "http://www.sciencemag.org/archive/",
+  Whittaker-number = "177",
+}
+
+@InCollection{Einstein:1940:FS,
+  author =       "Albert Einstein",
+  editor =       "Ruth Nanda Anshen",
+  booktitle =    "Freedom: Its Meaning",
+  title =        "Freedom and Science",
+  publisher =    "Harcourt Brace",
+  address =      "New York, NY, USA",
+  bookpages =    "xii + 686",
+  pages =        "??--??",
+  year =         "1940",
+  LCCN =         "JC585 .A55",
+  bibdate =      "Sat Jul 17 11:43:43 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated by James Gutmann.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "219",
+}
+
+@Article{Einstein:1940:GEP,
+  author =       "Albert Einstein and Leopold Infeld",
+  title =        "The gravitational equations and the problem of motion.
+                 {II}",
+  journal =      j-ANN-MATH-2,
+  volume =       "41",
+  number =       "2",
+  pages =        "455--464",
+  month =        apr,
+  year =         "1940",
+  CODEN =        "ANMAAH",
+  ISSN =         "0003-486X (print), 1939-8980 (electronic)",
+  ISSN-L =       "0003-486X",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0001689 (1,283b)",
+  MRreviewer =   "H. P. Robertson",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See also part I \cite{Einstein:1938:GEPa}.",
+  URL =          "2-6;
+                 http://links.jstor.org/sici?sici=0003-486X(194004)2:41:2<455:TGEATP>2.0.CO",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "223",
+  fjournal =     "Annals of Mathematics. Second Series",
+  received =     "29 May 1939",
+}
+
+@Article{Einstein:1940:MSJ,
+  author =       "Albert Einstein",
+  title =        "{Meine Stellung zur j{\"u}dischen Frage}. ({German})
+                 [{My} Position on the {Jewish} Question]",
+  journal =      "Aufbau",
+  volume =       "6",
+  number =       "52",
+  pages =        "9--9",
+  year =         "1940",
+  bibdate =      "Sat Jul 17 11:47:52 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "221",
+  language =     "German",
+}
+
+@Article{Einstein:1940:NBN,
+  author =       "Albert Einstein",
+  title =        "{Neuer Bund der Nationen}. ({German}) [{New} Bond
+                 Among Nations]",
+  journal =      "Aufbau",
+  volume =       "6",
+  number =       "26",
+  pages =        "1--2",
+  day =          "27",
+  month =        dec,
+  year =         "1940",
+  bibdate =      "Sat Jul 17 11:46:23 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "220",
+  language =     "German",
+}
+
+@Article{Einstein:1940:SR,
+  author =       "Albert Einstein",
+  title =        "Science and Religion",
+  journal =      j-NATURE,
+  volume =       "146",
+  number =       "3706",
+  pages =        "605--607",
+  day =          "9",
+  month =        nov,
+  year =         "1940",
+  CODEN =        "NATUAS",
+  DOI =          "http://dx.doi.org/10.1038/146605a0",
+  ISSN =         "0028-0836 (print), 1476-4687 (electronic)",
+  ISSN-L =       "0028-0836",
+  bibdate =      "Wed Oct 22 14:08:04 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://www.nature.com/nature/journal/v146/n3706/abs/146605a0.html",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Nature",
+  journal-URL =  "http://www.nature.com/nature/archive/",
+}
+
+@InCollection{Einstein:1940:SSA,
+  author =       "Albert Einstein",
+  editor =       "Robert Spiers Benjamin",
+  booktitle =    "{I} am an {American}: By Famous Naturalized
+                 {Americans}",
+  title =        "Statement on the significance of {American}
+                 citizenship",
+  publisher =    "Alliance Book",
+  address =      "New York, NY, USA",
+  bookpages =    "xi + 176",
+  pages =        "??--??",
+  year =         "1941",
+  LCCN =         "E169.1 .B45",
+  bibdate =      "Sat Jul 17 11:49:59 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "222",
+}
+
+@Book{Einstein:1940:WSI,
+  author =       "Albert Einstein",
+  title =        "The world as {I} see it",
+  publisher =    "Watts",
+  address =      "London, UK",
+  pages =        "xv + 112",
+  year =         "1940",
+  LCCN =         "????",
+  bibdate =      "Sat Sep 24 13:50:00 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 innopac.wits.ac.za:210/INNOPAC",
+  note =         "Translated by Alan Harris.",
+  series =       "Thinker's library.",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1941:CJ,
+  author =       "Albert Einstein",
+  title =        "Credo as a {Jew}",
+  journal =      "Universal Jewish Encyclopedia",
+  volume =       "4",
+  number =       "??",
+  pages =        "32--33",
+  year =         "1941",
+  bibdate =      "Sat Jul 17 11:59:34 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "227",
+}
+
+@Article{Einstein:1941:CLS,
+  author =       "Albert Einstein",
+  title =        "The Common Language of Science",
+  journal =      j-ADV-SCI,
+  volume =       "2",
+  number =       "5",
+  pages =        "109--110",
+  month =        "????",
+  year =         "1941",
+  CODEN =        "ADSCAH",
+  ISSN =         "0001-866X",
+  bibdate =      "Sat Sep 24 13:33:32 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Broadcast recording for Science Conference, London,
+                 UK, September 28, 1941.",
+  URL =          "http://www.youtube.com/watch?v=td2SReWxogY",
+  acknowledgement = ack-nhfb,
+  remark =       "Reprinted in Ideas and Opinions. Also
+                 available as YouTube video.",
+}
+
+@Article{Einstein:1941:DNE,
+  author =       "A. Einstein",
+  title =        "Demonstration of the non-existence of gravitational
+                 fields with a non-vanishing total mass free of
+                 singularities",
+  journal =      "Univ. Nac. Tucum{\'a}n. Revista A.",
+  volume =       "2",
+  pages =        "5--15",
+  year =         "1941",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0006877 (4,55c)",
+  MRreviewer =   "A. H. Taub",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/p/pauli-wolfgang.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "230",
+  Whittaker-number = "179",
+  xxnote =       "Calaprice has pages 11--15. Check!",
+}
+
+@InCollection{Einstein:1941:FDR,
+  author =       "A. Einstein and V. Bargmann and P. G. Bergmann",
+  booktitle =    "{Theodore von K{\'a}rm{\'a}n} Anniversary Volume",
+  title =        "On the five-dimensional representation of gravitation
+                 and electricity",
+  publisher =    "California Institute of Technology",
+  address =      "Pasadena, CA, USA",
+  pages =        "212--225",
+  year =         "1941",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0004790 (3,62b)",
+  MRreviewer =   "A. H. Taub",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "226",
+  Whittaker-number = "178",
+}
+
+@Book{Einstein:1941:GM,
+  author =       "Alfred Einstein",
+  title =        "Greatness in music",
+  publisher =    "Oxford university press",
+  address =      "New York, NY, USA",
+  pages =        "vii + 287",
+  year =         "1941",
+  LCCN =         "ML3847.E56 G7",
+  bibdate =      "Mon Oct 10 08:31:55 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+  author-dates = "1880--1952",
+  remark =       "Translation by C{\'e}sar Saerchinger (1889--1971) of
+                 Gr{\"o}sse in der Musik.",
+  subject =      "Music; Philosophy and aesthetics; Genius",
+}
+
+@InProceedings{Einstein:1941:NRG,
+  author =       "Albert Einstein",
+  editor =       "Anonymous",
+  booktitle =    "Science, Philosophy and Religion: a Symposium",
+  title =        "{Naturwissenschaft und Religion}. ({German})
+                 [{Science} and Religion]",
+  publisher =    "Conference on Science, Philosophy and Religion in
+                 Their Relation to the Democratic Way of Life, Inc.",
+  address =      "New York, NY, USA",
+  pages =        "??--??",
+  year =         "1941",
+  LCCN =         "????",
+  bibdate =      "Fri Jul 26 16:00:42 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite[pages 25--29]{Einstein:1952:MSJ}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@InProceedings{Einstein:1941:SRP,
+  author =       "Albert Einstein",
+  booktitle =    "Conference on Science, Philosophy and Religion in
+                 Their Democratic Way of Life",
+  title =        "Science and Religion, Part 2",
+  publisher =    "????",
+  address =      "New York, NY, USA",
+  year =         "1941",
+  bibdate =      "Sat Jul 17 11:57:11 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "225",
+}
+
+@Book{Einstein:1941:WSI,
+  author =       "Albert Einstein and Allen Harris",
+  title =        "The world as {I} see it",
+  publisher =    "J. Lane, The Bodley Head",
+  address =      "London, UK",
+  pages =        "214",
+  year =         "1941",
+  bibdate =      "Fri Nov 25 13:01:01 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 library.ox.ac.uk:210/ADVANCE",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Articles, addresses and manifestos of Albert Einstein
+                 \ldots{} a selection made \ldots{} to give a picture of
+                 a man. Originally published as Mein Weltbild. \ldots{}
+                 Translated from the German by Alan Harris.
+                 Scientific.--Judaism.--Germany, 1933.--Politics and
+                 pacifism.--The world as I see it.",
+  subject =      "Physics; Jews; Peace",
+}
+
+@Article{Einstein:1942:CLS,
+  author =       "Albert Einstein",
+  title =        "The Common Language of Science",
+  journal =      "Advancement of Science (London)",
+  volume =       "2",
+  number =       "5",
+  pages =        "109--109",
+  year =         "1942",
+  bibdate =      "Sat Jul 17 12:00:46 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Radio address to the British Association for the
+                 Advancement of Science, 28 September 1941. Reprinted in
+                 \cite[pp.~335--337]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "227, 228",
+}
+
+@Book{Einstein:1942:EPG,
+  author =       "Albert Einstein and Leopold Infeld",
+  title =        "The evolution of physics: the growth of ideas from
+                 early concepts to {Relativity} and quanta",
+  publisher =    pub-SIMON-SCHUSTER,
+  address =      pub-SIMON-SCHUSTER:adr,
+  pages =        "x + 319",
+  year =         "1942",
+  LCCN =         "QC7 .E5 1942",
+  bibdate =      "Mon Oct 9 06:48:08 MDT 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+  author-dates = "Albert Einstein (1879--1955); Leopold Infeld
+                 (1898--1968)",
+  subject =      "Physics; History; Relativity (physics); Quantum
+                 theory",
+}
+
+@Article{Einstein:1943:NER,
+  author =       "Albert Einstein and Wolfgang Pauli",
+  title =        "On the non-existence of regular stationary solutions
+                 of relativistic field equations",
+  journal =      j-ANN-MATH-2,
+  volume =       "44",
+  number =       "2",
+  pages =        "131--137",
+  month =        apr,
+  year =         "1943",
+  CODEN =        "ANMAAH",
+  ISSN =         "0003-486X (print), 1939-8980 (electronic)",
+  ISSN-L =       "0003-486X",
+  MRclass =      "84.0X",
+  MRnumber =     "MR0007992 (4,226d)",
+  MRreviewer =   "M. Wyman",
+  bibdate =      "Fri Jun 15 18:55:00 2012",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/p/pauli-wolfgang.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 MathSciNet database",
+  URL =          "2-Q;
+                 http://links.jstor.org/sici?sici=0003-486X(194304)2:44:2<131:OTNORS>2.0.CO",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "231",
+  fjournal =     "Annals of Mathematics (2)",
+  REP-number =   "56",
+  Whittaker-number = "180",
+}
+
+@Article{Einstein:1944:AP,
+  author =       "Albert Einstein and Erich Kahler",
+  title =        "The {Arabs} and {Palestine}",
+  journal =      "Princeton Herald",
+  day =          "14, 28",
+  month =        apr,
+  year =         "1944",
+  bibdate =      "Sat Jul 17 12:07:56 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "233",
+}
+
+@Article{Einstein:1944:BF,
+  author =       "Albert Einstein and Valentine Bargmann",
+  title =        "Bivector fields",
+  journal =      j-ANN-MATH-2,
+  volume =       "45",
+  pages =        "1--14",
+  month =        jan,
+  year =         "1944",
+  CODEN =        "ANMAAH",
+  ISSN =         "0003-486X (print), 1939-8980 (electronic)",
+  ISSN-L =       "0003-486X",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0009887 (5,218d)",
+  MRreviewer =   "A. H. Taub",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "2-7;
+                 http://links.jstor.org/sici?sici=0003-486X(194401)2:45:1<1:BF>2.0.CO",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "237",
+  fjournal =     "Annals of Mathematics. Second Series",
+  Whittaker-number = "182",
+}
+
+@Article{Einstein:1944:BFI,
+  author =       "A. Einstein",
+  title =        "Bivector fields. {II}",
+  journal =      j-ANN-MATH-2,
+  volume =       "45",
+  number =       "1",
+  pages =        "15--23",
+  month =        jan,
+  year =         "1944",
+  CODEN =        "ANMAAH",
+  ISSN =         "0003-486X (print), 1939-8980 (electronic)",
+  ISSN-L =       "0003-486X",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0009888 (5,218e)",
+  MRreviewer =   "A. H. Taub",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "2-I;
+                 http://links.jstor.org/sici?sici=0003-486X(194401)2:45:1<15:BFI>2.0.CO",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "238",
+  fjournal =     "Annals of Mathematics. Second Series",
+  Whittaker-number = "183",
+}
+
+@Article{Einstein:1944:EI,
+  author =       "Albert Einstein",
+  title =        "The Ethical Imperative",
+  journal =      "Opinion",
+  volume =       "14",
+  number =       "??",
+  pages =        "10--10",
+  year =         "1944",
+  bibdate =      "Sat Jul 17 12:13:14 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "236",
+}
+
+@InCollection{Einstein:1944:GS,
+  author =       "Albert Einstein",
+  booktitle =    "{Mahatma Gandhi}: Essays and Reflections on His Life
+                 and Work",
+  title =        "{Gandhi}'s Statesmanship",
+  publisher =    "Allen and Unwin",
+  address =      "London, UK",
+  bookpages =    "????",
+  pages =        "??--??",
+  year =         "1944",
+  LCCN =         "????",
+  bibdate =      "Sat Jul 17 12:05:23 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "232",
+}
+
+@Article{Einstein:1944:HBW,
+  author =       "Albert Einstein",
+  title =        "On the Heroes of the {Battle of the Warsaw Ghetto}",
+  journal =      "Bulletin of the Society of Polish Jews (New York)",
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  year =         "1944",
+  bibdate =      "Sat Jul 17 12:08:53 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "234",
+}
+
+@InCollection{Einstein:1944:RBR,
+  author =       "Albert Einstein",
+  editor =       "Paul A. Schilpp",
+  booktitle =    "The Philosophy of {Bertrand Russell}",
+  title =        "Remarks on {Bertrand Russell}'s Theory of Knowledge",
+  volume =       "5",
+  publisher =    "Open Court",
+  address =      "LaSalle, IL, USA",
+  bookpages =    "xv + 815",
+  pages =        "277--291",
+  year =         "1944",
+  ISSN =         "0075-9139",
+  ISSN-L =       "0075-9139",
+  LCCN =         "B1649.R94",
+  bibdate =      "Sat Jul 17 12:10:36 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "Library of Living Philosophers",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "235",
+  Whittaker-number = "181",
+}
+
+@Article{Einstein:1945:CP,
+  author =       "Albert Einstein",
+  title =        "On the Cosmological Problem",
+  journal =      "American Scholar",
+  volume =       "14",
+  number =       "??",
+  pages =        "137--156, 269",
+  year =         "1945",
+  bibdate =      "Sat Jul 17 12:18:10 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "240",
+}
+
+@Article{Einstein:1945:EAB,
+  author =       "Albert Einstein",
+  title =        "{Einstein} on the Atomic Bomb",
+  journal =      "Atlantic Monthly",
+  volume =       "176",
+  pages =        "43--45",
+  month =        nov,
+  year =         "1945",
+  bibdate =      "Sat Jul 17 12:15:19 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Edited by Raymond Swing. Reprinted as ``Atomic War or
+                 Peace, Part 1'', in \cite[pages
+                 118--123]{Einstein:1954:IO}. See part 2 in
+                 \cite{Einstein:1947:AWP}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "239",
+  remark =       "Article with same title in New York Times, October 27
+                 and 29, 1945.",
+}
+
+@Article{Einstein:1945:GRT,
+  author =       "Albert Einstein",
+  title =        "A generalization of the relativistic theory of
+                 gravitation",
+  journal =      j-ANN-MATH-2,
+  volume =       "46",
+  number =       "4",
+  pages =        "578--584",
+  month =        oct,
+  year =         "1945",
+  CODEN =        "ANMAAH",
+  ISSN =         "0003-486X (print), 1939-8980 (electronic)",
+  ISSN-L =       "0003-486X",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0014296 (7,266b)",
+  MRreviewer =   "M. Wyman",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "2-1;
+                 http://links.jstor.org/sici?sici=0003-486X(194510)2:46:4<578:AGOTRT>2.0.CO",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "241",
+  fjournal =     "Annals of Mathematics. Second Series",
+  Whittaker-number = "185",
+}
+
+@Article{Einstein:1945:HSE,
+  author =       "Albert Einstein",
+  title =        "On Harnessing Solar Energy",
+  journal =      j-NY-TIMES,
+  day =          "14",
+  month =        aug,
+  year =         "1945",
+  CODEN =        "NYTIAO",
+  ISSN =         "0362-4331 (print), 1542-667X, 1553-8095",
+  ISSN-L =       "0362-4331",
+  bibdate =      "Sat Jul 17 12:25:18 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "244",
+}
+
+@Article{Einstein:1945:IES,
+  author =       "Albert Einstein and Ernst G. Straus",
+  title =        "The influence of the expansion of space on the
+                 gravitation fields surrounding the individual stars",
+  journal =      j-REV-MOD-PHYS,
+  volume =       "17",
+  number =       "2--3",
+  pages =        "120--124",
+  month =        apr,
+  year =         "1945",
+  CODEN =        "RMPHAT",
+  DOI =          "http://dx.doi.org/10.1103/RevModPhys.17.120",
+  ISSN =         "0034-6861 (print), 1538-4527 (electronic), 1539-0756",
+  ISSN-L =       "0034-6861",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0012947 (7,87j)",
+  MRreviewer =   "M. Wyman",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See corrections and additional remarks
+                 \cite{Einstein:1946:CAR}.",
+  URL =          "http://link.aps.org/abstract/RMP/v17/p120;
+                 http://prola.aps.org/pdf/RMP/v17/i2-3/p120_1",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Reviews of Modern Physics",
+  Whittaker-number = "186a",
+}
+
+@Book{Einstein:1945:MR,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "135",
+  year =         "1945",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0012946 (7,87i)",
+  MRreviewer =   "G. C. McVittie",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Whittaker-number = "184",
+}
+
+@InCollection{Einstein:1945:TPE,
+  author =       "Albert Einstein",
+  editor =       "Jacques Hadamard",
+  booktitle =    "An Essay on the Psychology of Invention in the
+                 Mathematical World",
+  title =        "A Testimonial from {Prof. Einstein}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "142--143",
+  year =         "1945",
+  LCCN =         "????",
+  bibdate =      "Sat Jul 17 12:19:42 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite{Einstein:1996:MMP}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "243a",
+}
+
+@Article{Einstein:1946:CAR,
+  author =       "A. Einstein and E. G. Straus",
+  title =        "Corrections and additional remarks to our paper:
+                 ``{The influence of the expansion of space on the
+                 gravitation fields surrounding the individual
+                 stars}''",
+  journal =      j-REV-MOD-PHYS,
+  volume =       "18",
+  number =       "1",
+  pages =        "148--149",
+  month =        jan,
+  year =         "1946",
+  CODEN =        "RMPHAT",
+  DOI =          "http://dx.doi.org/10.1103/RevModPhys.18.148",
+  ISSN =         "0034-6861 (print), 1538-4527 (electronic), 1539-0756",
+  ISSN-L =       "0034-6861",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0015284 (7,397f)",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See \cite{Einstein:1945:IES}.",
+  URL =          "http://link.aps.org/abstract/RMP/v18/p148",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Reviews of Modern Physics",
+  Whittaker-number = "186b",
+}
+
+@Article{Einstein:1946:EDE,
+  author =       "Albert Einstein",
+  title =        "Elementary Derivation of the Equivalence of Mass and
+                 Energy",
+  journal =      "Technion Opinion",
+  volume =       "5",
+  number =       "??",
+  pages =        "16--17",
+  year =         "1946",
+  bibdate =      "Sat Jul 17 12:30:23 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "248",
+}
+
+@Article{Einstein:1946:GRT,
+  author =       "A. Einstein and E. G. Straus",
+  title =        "A generalization of the relativistic theory of
+                 gravitation. {II}",
+  journal =      j-ANN-MATH-2,
+  volume =       "47",
+  number =       "4",
+  pages =        "731--741",
+  month =        oct,
+  year =         "1946",
+  CODEN =        "ANMAAH",
+  ISSN =         "0003-486X (print), 1939-8980 (electronic)",
+  ISSN-L =       "0003-486X",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0019435 (8,412c)",
+  MRreviewer =   "M. Wyman",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "2-E;
+                 http://links.jstor.org/sici?sici=0003-486X(194610)2:47:4<731:AGOTRT>2.0.CO",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "247",
+  fjournal =     "Annals of Mathematics. Second Series",
+  Whittaker-number = "187",
+}
+
+@Article{Einstein:1946:JSG,
+  author =       "Albert Einstein",
+  title =        "{An die j{\"u}dischen Studenten}. ({German}) [{To} the
+                 {Jewish} Students]",
+  journal =      "Aufbau",
+  volume =       "12",
+  number =       "1",
+  pages =        "16--16",
+  year =         "1946",
+  bibdate =      "Sat Jul 17 12:28:58 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "246",
+  language =     "German",
+}
+
+@Book{Einstein:1946:MR,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-METHUEN,
+  address =      pub-METHUEN:adr,
+  edition =      "Third",
+  pages =        "v + 129",
+  year =         "1946",
+  LCCN =         "????",
+  bibdate =      "Wed Nov 23 11:43:11 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  remark =       "The text of the first edition published in 1922 was
+                 translated by Edwin Plimpton Adams. The new appendix is
+                 by Ernst G. Straus.",
+  subject =      "Relativity (Physics)",
+}
+
+@Article{Einstein:1946:MUP,
+  author =       "Albert Einstein",
+  title =        "{$ E = m c^2 $}: The Most Urgent Problem of Our Time",
+  journal =      "Science Illustrated",
+  volume =       "1",
+  pages =        "16--17",
+  month =        apr,
+  year =         "1946",
+  bibdate =      "Sat Jul 17 12:31:39 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite[pp.~337--341]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "249",
+}
+
+@InCollection{Einstein:1946:SOS,
+  author =       "Albert Einstein",
+  editor =       "Ben Raeburn",
+  booktitle =    "Treasury for the Free World",
+  title =        "Social Obligation of the Scientist",
+  publisher =    "Books for Libraries Press",
+  address =      "Freeport, NY, USA",
+  bookpages =    "xix + 417",
+  pages =        "??--??",
+  year =         "1946",
+  LCCN =         "D445 .R2 1972",
+  bibdate =      "Sat Jul 17 12:26:30 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Introduction by Ernest Hemingway.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "245",
+}
+
+@InCollection{Einstein:1946:U,
+  author =       "Albert Einstein",
+  title =        "Udvejen",
+  crossref =     "Masters:1946:VEI",
+  pages =        "??--??",
+  year =         "1946",
+  bibdate =      "Thu Sep 15 14:12:51 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1946:W,
+  author =       "Albert Einstein",
+  title =        "The way out",
+  crossref =     "Masters:1946:OWN",
+  pages =        "??--??",
+  year =         "1946",
+  bibdate =      "Thu Sep 15 14:12:51 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1947:AWP,
+  author =       "Albert Einstein",
+  title =        "Atomic War or Peace",
+  journal =      "Atlantic Monthly",
+  volume =       "180",
+  number =       "??",
+  pages =        "29--33",
+  month =        nov,
+  year =         "1947",
+  bibdate =      "Sat Jul 17 12:34:58 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted as ``Atomic War or Peace, Part 2'' in
+                 \cite{Einstein:1954:IO}. See part 1 in
+                 \cite{Einstein:1945:EAB}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "251",
+}
+
+@Book{Einstein:1947:EPG,
+  author =       "Albert Einstein and Leopold Infeld",
+  title =        "The evolution of physics: the growth of ideas from the
+                 early concepts to {Relativity} and quanta",
+  publisher =    pub-CAMBRIDGE,
+  address =      pub-CAMBRIDGE:adr,
+  pages =        "x + 319",
+  year =         "1947",
+  LCCN =         "????",
+  bibdate =      "Sat Sep 24 13:50:00 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 innopac.wits.ac.za:210/INNOPAC",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1947:MM,
+  author =       "Albert Einstein",
+  title =        "The Military Mentality",
+  journal =      "American Scholar",
+  volume =       "16",
+  number =       "??",
+  pages =        "353--354",
+  year =         "1947",
+  bibdate =      "Sat Jul 17 12:33:32 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite[pages
+                 132--134]{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "250",
+}
+
+@Article{Einstein:1947:OLU,
+  author =       "Albert Einstein",
+  title =        "Open letter to the {United Nations General Assembly}
+                 on how to ``break to vicious circle''",
+  journal =      "United Nations World",
+  volume =       "1",
+  number =       "??",
+  pages =        "13--14",
+  month =        oct,
+  year =         "1947",
+  bibdate =      "Sat Jul 17 12:38:40 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "253",
+}
+
+@InCollection{Einstein:1947:PSE,
+  author =       "Albert Einstein",
+  editor =       "Saxe Commins and R. N. Linscott",
+  booktitle =    "Man and the Universe",
+  title =        "The Problem of Space, Ether and the Field in Physics",
+  volume =       "4",
+  publisher =    pub-RANDOM-HOUSE,
+  address =      pub-RANDOM-HOUSE:adr,
+  bookpages =    "????",
+  pages =        "??--??",
+  year =         "1947",
+  LCCN =         "????",
+  bibdate =      "Sat Jul 17 12:39:57 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "The Great Thinkers",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "254",
+}
+
+@Article{Einstein:1947:REW,
+  author =       "Albert Einstein",
+  title =        "Response to the editor on {Walter White}'s article
+                 ``{Why} {I} Remain a Negro''",
+  journal =      "Saturday Review of Literature",
+  volume =       "30",
+  number =       "??",
+  pages =        "21--21",
+  day =          "1",
+  month =        nov,
+  year =         "1947",
+  bibdate =      "Sat Jul 17 12:37:21 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "252",
+}
+
+@Article{Einstein:1947:RRM,
+  author =       "Albert Einstein",
+  title =        "Replies to {Ridenour}: The Military Mentality",
+  journal =      j-BULL-AT-SCI,
+  volume =       "3",
+  number =       "8",
+  pages =        "223--224",
+  month =        aug,
+  year =         "1947",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Mon Sep 23 06:25:32 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Bulletin of the Atomic Scientists",
+}
+
+@Article{ECAS:1948:PSS,
+  author =       "{Emergency Committee of Atomic Scientists}",
+  title =        "A Policy For Survival: A Statement by {Emergency
+                 Committee of Atomic Scientists} --- {April 12, 1948}",
+  journal =      j-BULL-AT-SCI,
+  volume =       "4",
+  number =       "6",
+  pages =        "176, 188",
+  month =        jun,
+  year =         "1948",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Mon Sep 23 08:07:21 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Bulletin of the Atomic Scientists",
+  remark =       "ECAS members are Albert Einstein (Chairman), Harold C.
+                 Urey (Vice-Chairman), Harrison Brown, T. R. Hogness,
+                 Joseph E. Mayer, Philip M. Morse, H. J. Muller, and
+                 Frederick Seitz.",
+}
+
+@Article{Einstein:1948:ASR,
+  author =       "Albert Einstein",
+  title =        "Atomic Science Reading List",
+  journal =      "'48: Magazine of the Year",
+  pages =        "60--61",
+  month =        jan,
+  year =         "1948",
+  bibdate =      "Sat Jul 17 12:49:44 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "261",
+}
+
+@InCollection{Einstein:1948:F,
+  author =       "Albert Einstein",
+  booktitle =    "The {Hebrew University of Jerusalem}",
+  title =        "Foreword",
+  publisher =    "Goldberg's Press",
+  address =      "Jerusalem, Israel",
+  pages =        "??--??",
+  year =         "1948",
+  LCCN =         "????",
+  bibdate =      "Sat Jul 17 13:30:35 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "265",
+}
+
+@Article{Einstein:1948:GTG,
+  author =       "Albert Einstein",
+  title =        "A generalized theory of gravitation",
+  journal =      j-REV-MOD-PHYS,
+  volume =       "20",
+  number =       "1",
+  pages =        "35--39",
+  month =        jan,
+  year =         "1948",
+  CODEN =        "RMPHAT",
+  DOI =          "http://dx.doi.org/10.1103/RevModPhys.20.35",
+  ISSN =         "0034-6861 (print), 1538-4527 (electronic), 1539-0756",
+  ISSN-L =       "0034-6861",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0026460 (10,157g)",
+  MRreviewer =   "M. Wyman",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://link.aps.org/abstract/RMP/v20/p35;
+                 http://prola.aps.org/pdf/RMP/v20/i1/p35_1",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "260",
+  fjournal =     "Reviews of Modern Physics",
+  remark =       "See \cite{Einstein:1950:GTG} for a similar paper.",
+  Whittaker-number = "189",
+}
+
+@Article{Einstein:1948:LA,
+  author =       "Albert Einstein",
+  title =        "Looking Ahead",
+  journal =      "Rotarian",
+  volume =       "??",
+  number =       "??",
+  pages =        "8--10",
+  month =        jun,
+  year =         "1948",
+  bibdate =      "Sat Jul 17 12:47:39 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "258",
+}
+
+@Book{Einstein:1948:LDF,
+  author =       "Albert Einstein and Leopold Infeld",
+  title =        "{L}'evoluzione della fisica ({Italian}). [The
+                 evolution of physics]",
+  publisher =    "G. Einaudi",
+  address =      "Torino, Italy",
+  pages =        "310",
+  year =         "1948",
+  LCCN =         "QC7 .E515",
+  bibdate =      "Mon Oct 9 06:48:08 MDT 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  language =     "Italian",
+  subject =      "Physics; History; Relativity (physics); Quantum
+                 theory",
+}
+
+@Misc{Einstein:1948:LUM,
+  author =       "Albert Einstein",
+  title =        "Letter on universal military training addressed to the
+                 {Chairman} of the {Senate} committee",
+  howpublished = "US Congress, Senate, Committee on Armed Services,
+                 Hearings on Universal Military Training",
+  pages =        "257--257",
+  year =         "1948",
+  bibdate =      "Sat Jul 17 12:42:40 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Read 24 March 1948.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "255",
+}
+
+@Article{Einstein:1948:MWC,
+  author =       "Albert Einstein",
+  title =        "A Message to the {World Congress of Intellectuals}
+                 [{Breslau, West Germany, August 1948}]",
+  journal =      j-BULL-AT-SCI,
+  volume =       "4",
+  number =       "10",
+  pages =        "295, 299",
+  month =        oct,
+  year =         "1948",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Tue Sep 24 07:28:47 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See \cite{Anonymous:1948:PVE,Anonymous:1948:DEL}.",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Bulletin of the Atomic Scientists",
+}
+
+@Article{Einstein:1948:PIU,
+  author =       "Albert Einstein",
+  title =        "A Plea for International Understanding",
+  journal =      j-BULL-AT-SCI,
+  volume =       "4",
+  number =       "1",
+  pages =        "1--1",
+  month =        jan,
+  year =         "1948",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Tue Nov 05 06:30:06 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Bulletin of the Atomic Scientists",
+}
+
+@Article{Einstein:1948:PPS,
+  author =       "Albert Einstein",
+  title =        "Physics, Philosophy, and Scientific Progress",
+  journal =      "Journal of the International College of Surgeons",
+  volume =       "14",
+  number =       "??",
+  pages =        "755--758",
+  year =         "1948",
+  bibdate =      "Sat Jul 17 13:35:05 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "From tape-recorded address to a convention of the
+                 International College of Surgeons",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "268",
+}
+
+@Article{Einstein:1948:QMW,
+  author =       "A. Einstein",
+  title =        "{Quanten-Mechanik und Wirklichkeit}. ({German})
+                 [{Quantum} Mechanics and Reality]",
+  journal =      "Dialectica",
+  volume =       "2",
+  number =       "3-4",
+  pages =        "320--324",
+  month =        "????",
+  year =         "1948",
+  DOI =          "http://dx.doi.org/10.1111/j.1746-8361.1948.tb00704.x",
+  ISSN =         "1746-8361",
+  bibdate =      "Wed Dec 14 06:01:35 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "259",
+  language =     "German",
+  Whittaker-number = "188",
+}
+
+@Unpublished{Einstein:1948:ROW,
+  author =       "Albert Einstein",
+  title =        "On Receiving the {One World Award}",
+  year =         "1948",
+  bibdate =      "Sat Jul 17 12:46:28 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Address given at Carnegie Hall, April 27, 1948.
+                 Reprinted in \cite[pages 146--147]{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "257",
+}
+
+@Article{Einstein:1948:RSI,
+  author =       "Albert Einstein",
+  title =        "Religion and Science: Irreconcilable?",
+  journal =      "Christian Register",
+  volume =       "127",
+  number =       "??",
+  pages =        "19--20",
+  month =        jun,
+  year =         "1948",
+  bibdate =      "Sat Jul 17 12:44:25 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "256",
+}
+
+@Article{Einstein:1948:RSS,
+  author =       "Albert Einstein",
+  title =        "A Reply to the {Soviet} Scientists",
+  journal =      j-BULL-AT-SCI,
+  volume =       "4",
+  number =       "2",
+  pages =        "35--37",
+  month =        feb,
+  year =         "1948",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Thu Aug 23 06:31:31 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See \cite{Vavilov:1948:OLD}. Reprinted in
+                 \cite{Einstein:1963:ER}.",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Bulletin of the Atomic Scientists",
+}
+
+@Article{Einstein:1948:WS,
+  author =       "Albert Einstein",
+  title =        "Why Socialism?",
+  journal =      "Monthly Review: An Independent Socialist Magazine",
+  volume =       "1",
+  number =       "1",
+  pages =        "9--15",
+  month =        may,
+  year =         "1948",
+  bibdate =      "Sat Jul 17 13:25:18 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "262",
+}
+
+@InCollection{Einstein:1949:AN,
+  author =       "Albert Einstein",
+  title =        "Autobiographical Notes",
+  crossref =     "Schilpp:1949:AEPa",
+  pages =        "3--94",
+  year =         "1949",
+  bibdate =      "Sat Jul 17 13:28:30 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "264a",
+}
+
+@Article{Einstein:1949:DAE,
+  author =       "Albert Einstein and Robert A. Millikan",
+  title =        "{Dr. Albert Einstein} and {American} Colleagues,
+                 1931",
+  journal =      j-PROC-AMER-PHIL-SOC,
+  volume =       "93",
+  number =       "7",
+  pages =        "543--545",
+  day =          "30",
+  month =        dec,
+  year =         "1949",
+  CODEN =        "PAPCAA",
+  ISSN =         "0003-049X (print), 2326-9243 (electronic)",
+  ISSN-L =       "0003-049X",
+  bibdate =      "Fri Nov 25 11:23:22 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Theory of Relativity in Contemporary Science. Papers
+                 Read at the Celebration of the Seventieth Birthday of
+                 Professor Albert Einstein in Princeton, March 19,
+                 1949.",
+  URL =          "http://links.jstor.org/sici?sici=0003-049X(19491230)93:7<543:DAEAAC>2.0.CO%3B2-U;
+                 http://www.jstor.org/stable/3143144",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Proceedings of the {American Philosophical Society}
+                 held at {Philadelphia} for promoting useful knowledge",
+  journal-URL =  "http://www.jstor.org/journal/procamerphilsoci",
+}
+
+@Article{Einstein:1949:HFR,
+  author =       "Hans Albert Einstein and El-Sayed Ahmed El-Samni",
+  title =        "Hydrodynamic Forces on a Rough Wall",
+  journal =      j-REV-MOD-PHYS,
+  volume =       "21",
+  number =       "3",
+  pages =        "520--524",
+  month =        jul,
+  year =         "1949",
+  CODEN =        "RMPHAT",
+  DOI =          "http://dx.doi.org/10.1103/RevModPhys.21.520",
+  ISSN =         "0034-6861 (print), 1538-4527 (electronic), 1539-0756",
+  ISSN-L =       "0034-6861",
+  bibdate =      "Tue May 22 16:36:38 MDT 2012",
+  bibsource =    "http://rmp.aps.org/toc/RMP/v21/i3;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 http://www.math.utah.edu/pub/tex/bib/revmodphys1940.bib",
+  note =         "Special issue in honor of Albert Einstein on his 70th
+                 birthday.",
+  URL =          "http://link.aps.org/doi/10.1103/RevModPhys.21.520;
+                 http://rmp.aps.org/abstract/RMP/v21/i3/p520_1",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Reviews of Modern Physics",
+}
+
+@Article{Einstein:1949:MPG,
+  author =       "Albert Einstein and Leopold Infeld",
+  title =        "On the motion of particles in {General Relativity
+                 Theory}",
+  journal =      j-CAN-J-MATH,
+  volume =       "1",
+  number =       "1",
+  pages =        "209--241 + 1",
+  month =        "????",
+  year =         "1949",
+  CODEN =        "CJMAAB",
+  DOI =          "http://dx.doi.org/10.4153/CJM-1949-020-8",
+  ISSN =         "0008-414X (print), 1496-4279 (electronic)",
+  ISSN-L =       "0008-414X",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0030825 (11,59a)",
+  MRreviewer =   "G. C. McVittie",
+  bibdate =      "Sat Sep 10 15:38:24 MDT 2011",
+  bibsource =    "http://cms.math.ca/cjm/v1/;
+                 http://www.math.utah.edu/pub/tex/bib/canjmath1940.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 MathSciNet database",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "266",
+  fjournal =     "Canadian Journal of Mathematics = Journal canadien de
+                 math{\'e}matiques",
+  Whittaker-number = "190",
+  xxnote =       "Calaprice has pages 209--214, but the second is
+                 correctly 241.",
+}
+
+@Article{Einstein:1949:OLF,
+  author =       "Albert Einstein",
+  title =        "Open Letter to Friends of the {Emergency Committee}",
+  journal =      j-BULL-AT-SCI,
+  volume =       "5",
+  number =       "6--7",
+  pages =        "206--206",
+  month =        jun # "\slash " # jul,
+  year =         "1949",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Tue Sep 24 15:34:54 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Bulletin of the Atomic Scientists",
+}
+
+@Book{Einstein:1949:PAE,
+  author =       "Albert Einstein and Leopold Infeld",
+  title =        "{Physik als Abenteuer de Erkenntnis}. ({German})
+                 [{The} Evolution of Physics]",
+  publisher =    "A. W. Sijthoff",
+  address =      "Leiden, The Netherlands",
+  edition =      "Second",
+  pages =        "200",
+  year =         "1949",
+  LCCN =         "QC7 .E514",
+  bibdate =      "Mon Aug 4 07:01:47 MDT 2008",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  language =     "German",
+  remark =       "Translation of The evolution of physics.",
+  subject =      "Physics; History; Relativity (Physics); Quantum
+                 theory",
+}
+
+@InCollection{Einstein:1949:REA,
+  author =       "Albert Einstein",
+  title =        "Remarks to the Essays Appearing in This Volume",
+  crossref =     "Schilpp:1949:AEPa",
+  pages =        "665--688",
+  year =         "1949",
+  bibdate =      "Sat Jul 17 13:28:30 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "264b",
+}
+
+@Article{Einstein:1949:SAB,
+  author =       "Albert Einstein",
+  title =        "In the Shadow of the Atomic Bomb",
+  journal =      "Southern Patriot",
+  volume =       "7",
+  number =       "3",
+  pages =        "??--??",
+  year =         "1949",
+  bibdate =      "Sat Jul 17 13:26:11 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "263",
+}
+
+@Book{Einstein:1949:WSI,
+  author =       "Albert Einstein",
+  title =        "The world as {I} see it",
+  publisher =    pub-PHILOSOPHICAL-LIBRARY,
+  address =      pub-PHILOSOPHICAL-LIBRARY:adr,
+  pages =        "xiii + 112",
+  year =         "1949",
+  ISBN =         "0-8065-0711-X",
+  ISBN-13 =      "978-0-8065-0711-8",
+  LCCN =         "AC35 .E528",
+  bibdate =      "Mon Oct 9 19:00:51 MDT 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  note =         "Translated by Alan Harris.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Physics; Jews; Peace",
+}
+
+@Article{Einstein:1950:ACB,
+  author =       "Albert Einstein",
+  title =        "Arms Can Bring No Security",
+  journal =      j-BULL-AT-SCI,
+  volume =       "6",
+  number =       "3",
+  pages =        "71--71",
+  month =        mar,
+  year =         "1950",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Tue Jul 30 07:13:49 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Bulletin of the Atomic Scientists",
+}
+
+@Article{Einstein:1950:BIG,
+  author =       "A. Einstein",
+  title =        "The {Bianchi} identities in the generalized theory of
+                 gravitation",
+  journal =      j-CAN-J-MATH,
+  volume =       "2",
+  pages =        "120--128",
+  year =         "1950",
+  CODEN =        "CJMAAB",
+  ISSN =         "0008-414X (print), 1496-4279 (electronic)",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0034134 (11,548a)",
+  MRreviewer =   "M. Wyman",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "271",
+  Whittaker-number = "191",
+}
+
+@Book{Einstein:1950:CSM,
+  author =       "Albert Einstein",
+  title =        "Conceptions: scientifiques, morales, et sociales.
+                 ({French}) [Scientific, moral, and social
+                 conceptions]",
+  publisher =    "Flammarion",
+  address =      "Paris, France",
+  pages =        "316",
+  year =         "1950",
+  LCCN =         "QC16.E5 A314",
+  bibdate =      "Fri Nov 25 11:31:38 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "French translation of {\em Out of my later years}.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@InCollection{Einstein:1950:F,
+  author =       "Albert Einstein",
+  title =        "Foreword",
+  crossref =     "Frank:1950:RRT",
+  pages =        "??--??",
+  year =         "1950",
+  bibdate =      "Sat Jul 17 13:40:42 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "272",
+}
+
+@Article{Einstein:1950:GTG,
+  author =       "Albert Einstein",
+  title =        "On the {Generalized Theory of Gravitation}",
+  journal =      j-SCI-AMER,
+  volume =       "182",
+  number =       "4",
+  pages =        "13--17",
+  month =        apr,
+  year =         "1950",
+  CODEN =        "SCAMAC",
+  DOI =          "http://dx.doi.org/10.1038/scientificamerican0450-13",
+  ISSN =         "0036-8733 (print), 1946-7087 (electronic)",
+  ISSN-L =       "0036-8733",
+  bibdate =      "Sat May 18 15:56:38 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 http://www.math.utah.edu/pub/tex/bib/sciam1950.bib",
+  note =         "Reprinted in \cite[pp.~341--356]{Einstein:1982:IO}.",
+  URL =          "http://www.nature.com/scientificamerican/journal/v182/n4/pdf/scientificamerican0450-13.pdf",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "270",
+  fjournal =     "Scientific American",
+  journal-URL =  "http://www.nature.com/scientificamerican",
+}
+
+@InCollection{Einstein:1950:I,
+  author =       "Albert Einstein",
+  title =        "Introduction",
+  crossref =     "Eliot:1950:HB",
+  year =         "1950",
+  pages =        "??--??",
+  acknowledgement = ack-nhfb,
+  bibdate =      "Tue Feb 17 11:29:34 2015",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+}
+
+@Article{Einstein:1950:MIS,
+  author =       "Albert Einstein",
+  title =        "Message to the {Italian Society for the Advancement of
+                 Science}",
+  journal =      "Impact",
+  pages =        "??--??",
+  month =        "Fall",
+  year =         "1950",
+  bibdate =      "Sat Jul 17 13:41:32 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Sent to the group's forty-second meeting in Lucca,
+                 Italy. English translation in
+                 \cite[pp.~356--359]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+  keywords =     "UNESCO journal",
+}
+
+@Book{Einstein:1950:MLYa,
+  author =       "Albert Einstein",
+  title =        "Out of my later years",
+  publisher =    pub-PHILOSOPHICAL-LIBRARY,
+  address =      pub-PHILOSOPHICAL-LIBRARY:adr,
+  pages =        "vii + 282",
+  year =         "1950",
+  LCCN =         "QC16.E5 A3",
+  bibdate =      "Fri Nov 25 11:31:38 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1950:MLYb,
+  author =       "Albert Einstein",
+  title =        "Out of my later years",
+  publisher =    "Thames and Hudson",
+  address =      "London, UK",
+  pages =        "viii + 282",
+  year =         "1950",
+  LCCN =         "QC16.E5 A3",
+  bibdate =      "Fri Nov 25 11:31:38 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1950:MOS,
+  author =       "Albert Einstein",
+  title =        "On the Moral Obligation of Science",
+  journal =      "Impact",
+  volume =       "1",
+  number =       "??",
+  pages =        "104--105",
+  year =         "1950",
+  bibdate =      "Sat Jul 17 13:34:12 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "267",
+}
+
+@Book{Einstein:1950:MRa,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-METHUEN,
+  address =      pub-METHUEN:adr,
+  edition =      "Fourth",
+  pages =        "145",
+  year =         "1950",
+  LCCN =         "????",
+  bibdate =      "Wed Nov 23 11:43:11 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  xxpages =      "162",
+}
+
+@Book{Einstein:1950:MRb,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  edition =      "Third",
+  pages =        "150",
+  year =         "1950",
+  LCCN =         "QC6",
+  bibdate =      "Wed Nov 23 11:43:11 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Includes the Generalized Theory of Gravitation.",
+  acknowledgement = ack-nhfb,
+  Whittaker-number = "192",
+  xpages =       "162",
+}
+
+@Book{Einstein:1950:MRT,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  edition =      "Third",
+  pages =        "iv + 165",
+  year =         "1950",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0048945 (14,97a)",
+  MRreviewer =   "A. H. Taub",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Includes the Generalized Theory of Gravitation.",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1950:OLS,
+  author =       "Albert Einstein",
+  title =        "An Open Letter to the {Society for Social
+                 Responsibility}",
+  journal =      j-SCIENCE,
+  volume =       "112",
+  number =       "??",
+  pages =        "760--761",
+  year =         "1950",
+  CODEN =        "SCIEAS",
+  ISSN =         "0036-8075 (print), 1095-9203 (electronic)",
+  ISSN-L =       "0036-8075",
+  bibdate =      "Sat Jul 17 13:36:37 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted as ``The State and the Individual
+                 Conscience'' in \cite[pp. 26--27]{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "269",
+  journal-URL =  "http://www.sciencemag.org/archive/",
+  remark =       "Letter written 22 December 1950.",
+}
+
+@Article{Einstein:1950:PPS,
+  author =       "A. Einstein",
+  title =        "Physics, philosophy and scientific progress",
+  journal =      "The Journal of the International College of Surgeons",
+  volume =       "14",
+  number =       "6",
+  pages =        "755--758",
+  month =        dec,
+  year =         "1950",
+  ISSN =         "0096-557X",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1950:SRS,
+  author =       "A. Einstein",
+  title =        "Social Responsibility in Science",
+  journal =      j-SCIENCE,
+  volume =       "112",
+  number =       "2921",
+  pages =        "760--761",
+  day =          "22",
+  month =        dec,
+  year =         "1950",
+  CODEN =        "SCIEAS",
+  DOI =          "http://dx.doi.org/10.1126/science.112.2921.760-b",
+  ISSN =         "0036-8075",
+  ISSN-L =       "0036-8075",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Science (New York, N.Y.)",
+  journal-URL =  "http://www.sciencemag.org/archive/",
+}
+
+@Article{Einstein:1951:AQT,
+  author =       "Albert Einstein",
+  title =        "The Advent of the Quantum Theory",
+  journal =      j-SCIENCE,
+  volume =       "113",
+  number =       "2926",
+  pages =        "82--84",
+  day =          "26",
+  month =        jan,
+  year =         "1951",
+  CODEN =        "SCIEAS",
+  DOI =          "http://dx.doi.org/10.1126/science.113.2926.82",
+  ISSN =         "0036-8075 (print), 1095-9203 (electronic)",
+  ISSN-L =       "0036-8075",
+  bibdate =      "Sat Jul 17 13:46:08 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "275",
+  fjournal =     "Science",
+  journal-URL =  "http://www.sciencemag.org/archive/",
+}
+
+@Article{Einstein:1951:CM,
+  author =       "Albert Einstein",
+  title =        "Concern for Man",
+  journal =      j-BULL-AT-SCI,
+  volume =       "7",
+  number =       "7--8",
+  pages =        "204--204",
+  month =        aug,
+  year =         "1951",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Wed Sep 25 05:31:00 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Bulletin of the Atomic Scientists",
+  remark =       "Two-sentence quote",
+}
+
+@InCollection{Einstein:1951:Fa,
+  author =       "Albert Einstein",
+  editor =       "Dagobert D. Runes",
+  booktitle =    "{Spinoza}: Dictionary",
+  title =        "Foreword",
+  publisher =    pub-PHILOSOPHICAL-LIBRARY,
+  address =      pub-PHILOSOPHICAL-LIBRARY:adr,
+  pages =        "??--??",
+  year =         "1951",
+  LCCN =         "B3951 .S5",
+  bibdate =      "Sat Jul 17 13:43:30 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "274",
+  subject-dates = "Benedictus de Spinoza, 1632--1677",
+}
+
+@InCollection{Einstein:1951:Fb,
+  author =       "Albert Einstein",
+  editor =       "Homer Smith",
+  booktitle =    "Man and His Gods",
+  title =        "Foreword",
+  publisher =    pub-LITTLE-BROWN,
+  address =      pub-LITTLE-BROWN:adr,
+  pages =        "??--??",
+  year =         "1951",
+  LCCN =         "????",
+  bibdate =      "Sat Jul 17 13:49:00 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "277",
+}
+
+@Book{Einstein:1951:GMG,
+  author =       "Albert Einstein",
+  title =        "Gr{\"o}sse in der Musik. ({German}) [Greatness in
+                 Musik]",
+  publisher =    "Pan-Verlag",
+  address =      "Z{\"u}rich, Switzerland",
+  pages =        "252",
+  year =         "1951",
+  bibdate =      "Mon Oct 10 08:37:21 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  remark =       "German translation of 1941 English original.",
+}
+
+@InCollection{Einstein:1951:I,
+  author =       "Albert Einstein",
+  editor =       "Carola Baumgardt",
+  booktitle =    "{Johannes Kepler}: Life and Letters",
+  title =        "Introduction",
+  publisher =    pub-PHILOSOPHICAL-LIBRARY,
+  address =      pub-PHILOSOPHICAL-LIBRARY:adr,
+  pages =        "??--??",
+  year =         "1951",
+  LCCN =         "????",
+  bibdate =      "Sat Jul 17 13:47:22 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "276",
+}
+
+@Book{Einstein:1951:PCT,
+  author =       "Albert Einstein",
+  title =        "Sur le probl{\`e}me cosmologique. {Th}{\'e}orie de la
+                 gravitation g{\'e}n{\'e}ralis{\'e}e. ({French}) [{On}
+                 the cosmological problem. {Generalized} theory of
+                 gravitation]",
+  publisher =    pub-GAUTHIER-VILLARS,
+  address =      pub-GAUTHIER-VILLARS:adr,
+  pages =        "54",
+  year =         "1951",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0053650 (14,805b)",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated from English par Maurice Solovine.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Book{Samuel:1951:EP,
+  author =       "Viscount Herbert Louis Samuel and Albert Einstein",
+  title =        "Essay in physics",
+  publisher =    "Blackwell",
+  address =      "Oxford, UK",
+  pages =        "154",
+  year =         "1951",
+  LCCN =         "QC 6 SAM",
+  bibdate =      "Sat Sep 24 13:50:00 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 innopac.wits.ac.za:210/INNOPAC",
+  acknowledgement = ack-nhfb,
+  remark =       "With a letter from Albert Einstein.",
+  subject =      "Physics; Philosophy",
+}
+
+@Book{Einstein:1952:CSM,
+  author =       "Albert Einstein",
+  title =        "Conceptions scientifiques, morales, et sociales.
+                 ({French}) [{Scientific}, moral, and social concepts]",
+  publisher =    "Flammarion",
+  address =      "Paris, France",
+  pages =        "316",
+  year =         "1952",
+  LCCN =         "QC16.E5 A314",
+  bibdate =      "Sat Oct 28 15:52:15 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "French translation of \cite{Einstein:1950:MLYb}.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Article{Einstein:1952:ESG,
+  author =       "Albert Einstein and Hans A. Bethe and Harold C. Urey
+                 and James Franck and Samuel Goudsmit and Cyril S. Smith
+                 and Arthur H. Compton and William P. Murphy",
+  title =        "Eminent Scientists Give Their Views on {American} Visa
+                 Policy",
+  journal =      j-BULL-AT-SCI,
+  volume =       "8",
+  number =       "7",
+  pages =        "217--220",
+  month =        oct,
+  year =         "1952",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Sat Jul 14 10:48:59 2012",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/b/bethe-hans.bib;
+                 http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Issue devoted to the restrictions of the McCarran Acts
+                 --- the Internal Security Act of 1950, and the
+                 Immigration and Nationality Act of 1952 --- on freedom
+                 of travel by scientists across US borders..",
+  acknowledgement = ack-nhfb,
+  author-dates = "Hans Albrecht Bethe (1906--2005)",
+  fjournal =     "Bulletin of the Atomic Scientists",
+  keywords =     "Linus Pauling; McCarran Acts",
+}
+
+@Book{Einstein:1952:MSJ,
+  author =       "Albert Einstein",
+  title =        "{Aus meinen sp{\"a}ten Jahren}. ({German}) [{Out} of
+                 my later years]",
+  publisher =    "Deutsche Verlagsanstalt",
+  address =      "Stuttgart, West Germany",
+  pages =        "278",
+  year =         "1952",
+  LCCN =         "????",
+  bibdate =      "Fri Jul 26 16:02:50 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "German translation by Hildegard Blomeyer of
+                 \cite{Einstein:1950:MLYa}.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1952:MOS,
+  author =       "Albert Einstein",
+  title =        "On the Moral Obligation of the Scientist",
+  journal =      j-BULL-AT-SCI,
+  volume =       "8",
+  number =       "2",
+  pages =        "34--35",
+  month =        feb,
+  year =         "1952",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Wed Sep 25 07:15:08 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Bulletin of the Atomic Scientists",
+}
+
+@Article{Einstein:1952:SCD,
+  author =       "Albert Einstein",
+  title =        "Symptoms of Cultural Decay",
+  journal =      j-BULL-AT-SCI,
+  volume =       "8",
+  number =       "7",
+  pages =        "166--167",
+  month =        oct,
+  year =         "1952",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Sat Jul 17 13:53:41 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Issue devoted to the restrictions of the McCarran Acts
+                 --- the Internal Security Act of 1950, and the
+                 Immigration and Nationality Act of 1952 --- on freedom
+                 of travel by scientists across US borders. Reprinted in
+                 \cite[pp. 166--167]{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "279",
+  fjournal =     "Bulletin of the Atomic Scientists",
+}
+
+@Article{Einstein:1952:WNZ,
+  author =       "Albert Einstein",
+  title =        "{Wer nur Zeitungen liest, sieht die Dinge wie ein
+                 Kurzsichtiger ohne Augengl{\"a}ser}. ({German})
+                 [{Those} Who Read Only Newspapers See Things Like a
+                 Nearsighted Person without Glasses]",
+  journal =      "Der Jungkaufmann (Z{\"u}rich)",
+  volume =       "27",
+  number =       "4",
+  pages =        "73--73",
+  year =         "1952",
+  bibdate =      "Sat Jul 17 13:50:40 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in English translation in \cite[pp.
+                 64--65]{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "278",
+  language =     "German",
+}
+
+@InCollection{Einstein:1953:A,
+  author =       "A. Einstein",
+  title =        "Appendice",
+  crossref =     "George:1953:LBP",
+  pages =        "337--342",
+  year =         "1953",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0066806 (16,634b)",
+  MRreviewer =   "V. Hlavat{\'y}",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1953:CCU,
+  author =       "Albert Einstein",
+  title =        "A Comment on a Criticism of {Unified Field Theory}",
+  journal =      j-PHYS-REV-2,
+  volume =       "89",
+  number =       "1",
+  pages =        "321--321",
+  day =          "1",
+  month =        jan,
+  year =         "1953",
+  CODEN =        "PHRVAO",
+  DOI =          "http://dx.doi.org/10.1103/PhysRev.89.321",
+  ISSN =         "0031-899X (print), 1536-6065 (electronic)",
+  ISSN-L =       "0031-899X",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0052233 (14,591g)",
+  MRreviewer =   "A. H. Taub",
+  bibdate =      "Sat Jul 17 13:57:03 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://link.aps.org/abstract/PR/v89/p321;
+                 http://prola.aps.org/pdf/PR/v89/i1/p321_1",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "281",
+  Whittaker-number = "193",
+}
+
+@InCollection{Einstein:1953:EAT,
+  author =       "A. Einstein and B. Kaufman",
+  title =        "Sur l'{\'e}tat actuel de la th{\'e}orie
+                 g{\'e}n{\'e}rale de la gravitation. ({French}) [{On}
+                 the current state of the {General Theory of
+                 Gravitation}]",
+  crossref =     "George:1953:LBP",
+  pages =        "321--336",
+  year =         "1953",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0066805 (16,634a)",
+  MRreviewer =   "V. Hlavat{\'y}",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@InCollection{Einstein:1953:EBG,
+  author =       "Albert Einstein",
+  title =        "{Einleitende Bemerkungen {\"u}ber Grundbegriffe}.
+                 {Remarques} pr{\'e}liminaires sur les concepts
+                 fondamentaux. ({German\slash French}) [Preliminary
+                 remarks on fundamental concepts]",
+  crossref =     "George:1953:LBP",
+  pages =        "4--15",
+  year =         "1953",
+  MRclass =      "81.0X",
+  MRnumber =     "MR0067757 (16,777d)",
+  MRreviewer =   "A. H. Taub",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@InCollection{Einstein:1953:EUI,
+  author =       "Albert Einstein",
+  title =        "{Elementare {\"u}berlegungen zur Interpretation der
+                 Grundlagen der Quanten-Mechanik}. ({German})
+                 [{Elementary} considerations for the interpretation of
+                 the foundation of quantum mechanics]",
+  crossref =     "Appleton:1953:SPP",
+  pages =        "33--40",
+  year =         "1953",
+  MRclass =      "81.0X",
+  MRnumber =     "MR0061024 (15,764d)",
+  MRreviewer =   "H. C. Corben",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "282",
+  language =     "German",
+  Whittaker-number = "196",
+}
+
+@InCollection{Einstein:1953:F,
+  author =       "Albert Einstein",
+  title =        "Foreword",
+  crossref =     "Drake:1953:GGD",
+  pages =        "??--??",
+  year =         "1953",
+  bibdate =      "Wed Oct 22 14:48:43 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1953:JPF,
+  author =       "Albert Einstein",
+  title =        "To the {Jewish} Peace Fellowship",
+  journal =      "Tidings",
+  volume =       "8",
+  number =       "1",
+  pages =        "3--3",
+  year =         "1953",
+  bibdate =      "Sat Jul 17 13:55:36 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Also in volume 9(2) 5--5.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "280",
+}
+
+@Article{Einstein:1953:LRW,
+  author =       "Albert Einstein",
+  title =        "Letter in Reply To {William Frauenglass}",
+  journal =      j-BULL-AT-SCI,
+  volume =       "9",
+  number =       "6",
+  pages =        "229--230",
+  month =        jul,
+  year =         "1953",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Sat Jul 17 14:01:22 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite[pages 33--34]{Einstein:1954:IO}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "284",
+}
+
+@Unpublished{Einstein:1953:MAC,
+  author =       "Albert Einstein",
+  title =        "Message to the {24th Annual Conference of the War
+                 Resister's League}",
+  day =          "10",
+  month =        aug,
+  year =         "1953",
+  bibdate =      "Sat Jul 17 14:02:40 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "New York, NY, USA",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "285",
+}
+
+@Misc{Einstein:1953:MAD,
+  author =       "Albert Einstein",
+  title =        "Message on the 410th Anniversary of the Death of
+                 {Copernicus}",
+  howpublished = "On the occasion of the commemoration evening, Columbia
+                 University, New York, NY.",
+  month =        dec,
+  year =         "1953",
+  bibdate =      "Fri Aug 13 10:05:03 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted in \cite[pp.~359--360]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1953:MRa,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  edition =      "Fourth",
+  pages =        "165",
+  year =         "1953",
+  LCCN =         "QC6",
+  bibdate =      "Wed Nov 23 11:43:11 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  remark =       "Includes the generalization of gravitation theory.",
+}
+
+@Book{Einstein:1953:MRb,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  edition =      "Fourth",
+  pages =        "iv + 168",
+  year =         "1953",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0053649 (14,805a)",
+  MRreviewer =   "A. H. Taub",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Whittaker-number = "194",
+}
+
+@Book{Einstein:1953:MWG,
+  author =       "Albert Einstein",
+  title =        "{Mein Weltbild}. ({German}) [{My} World View]",
+  publisher =    "Europa Verlag",
+  address =      "Z{\"u}rich, Switzerland",
+  pages =        "257",
+  year =         "1953",
+  LCCN =         "????",
+  bibdate =      "Fri Jul 26 16:12:49 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Edited by Carl Seelig.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@InCollection{Einstein:1953:P,
+  author =       "Albert Einstein",
+  editor =       "Galileo Galilei",
+  booktitle =    "Dialogue concerning the two chief world systems,
+                 {Ptolemaic} \& {Copernican}",
+  title =        "Preface",
+  publisher =    pub-U-CALIFORNIA-PRESS,
+  address =      pub-U-CALIFORNIA-PRESS:adr,
+  pages =        "??--??",
+  year =         "1953",
+  LCCN =         "QB41 .G1356",
+  bibdate =      "Sat Jul 17 13:58:38 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated by Stillman Drake, with foreword by Albert
+                 Einstein.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "283",
+}
+
+@Book{Einstein:1953:SAI,
+  author =       "Albert Einstein",
+  title =        "Supplement to {Appendix II} of ``{The} meaning of
+                 {Relativity}, 4th edition''",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "8",
+  year =         "1953",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0058336 (15,357e)",
+  MRreviewer =   "A. H. Taub",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Whittaker-number = "195",
+}
+
+@Article{Einstein:1954:APF,
+  author =       "Albert Einstein and Bruria Kaufman",
+  title =        "Algebraic properties of the field in the relativistic
+                 theory of the asymmetric field",
+  journal =      j-ANN-MATH-2,
+  volume =       "59",
+  number =       "1",
+  pages =        "230--244",
+  month =        jan,
+  year =         "1954",
+  CODEN =        "ANMAAH",
+  ISSN =         "0003-486X (print), 1939-8980 (electronic)",
+  ISSN-L =       "0003-486X",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0062537 (15,994e)",
+  MRreviewer =   "A. G. Walker",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "2-W;
+                 http://links.jstor.org/sici?sici=0003-486X(195403)2:59:2<230:APOTFI>2.0.CO",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "287",
+  fjournal =     "Annals of Mathematics. Second Series",
+  Whittaker-number = "197",
+}
+
+@InCollection{Einstein:1954:F,
+  author =       "Albert Einstein",
+  editor =       "Max Jammer",
+  booktitle =    "Concepts of Space: the history of theories of space in
+                 physics",
+  title =        "Foreword",
+  publisher =    pub-HARVARD,
+  address =      pub-HARVARD:adr,
+  bookpages =    "196",
+  pages =        "??--??",
+  year =         "1954",
+  LCCN =         "QC6 .J3",
+  bibdate =      "Sat Jul 17 14:04:32 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See also later editions
+                 \cite{Einstein:1969:F,Einstein:1993:F}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "288a",
+}
+
+@Article{Einstein:1954:IEW,
+  author =       "Albert Einstein",
+  title =        "If {Einstein} Were Young Again, He Says He'd Become a
+                 Plumber",
+  journal =      j-NY-TIMES,
+  volume =       "??",
+  number =       "??",
+  pages =        "??--??",
+  day =          "10",
+  month =        nov,
+  year =         "1954",
+  CODEN =        "NYTIAO",
+  ISSN =         "0362-4331 (print), 1542-667X, 1553-8095",
+  ISSN-L =       "0362-4331",
+  bibdate =      "Sat Jul 17 14:14:53 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Based on letter written to the editor of The Report
+                 Magazine on 13 October 1954.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "290",
+}
+
+@Book{Einstein:1954:IO,
+  author =       "Albert Einstein",
+  title =        "Ideas and Opinions",
+  publisher =    pub-CROWN,
+  address =      pub-CROWN:adr,
+  pages =        "377",
+  year =         "1954",
+  LCCN =         "AC35 .E526",
+  bibdate =      "Wed Nov 23 11:44:31 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Based on {\em Mein Weltbild}, edited by Carl Seelig,
+                 and other sources. New translations and revisions by
+                 Sonja Bargmann.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "286",
+}
+
+@InCollection{Einstein:1954:RPS,
+  author =       "Albert Einstein",
+  title =        "{Relativity} and the Problem of Space",
+  crossref =     "Einstein:1954:RSG",
+  year =         "1954",
+  bibdate =      "Fri Aug 13 10:08:01 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Portion reprinted in
+                 \cite[pp.~360--377]{Einstein:1982:IO}.",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1954:SAR,
+  author =       "Albert Einstein",
+  title =        "{{\"U}ber die spezielle und allgemeine
+                 Relativit{\"a}tstheorie: gemeinverst{\"a}ndlich}.
+                 ({German}) [{On Special and General Relativity}]",
+  publisher =    pub-VIEWEG,
+  address =      pub-VIEWEG:adr,
+  pages =        "viii + 104",
+  year =         "1954",
+  bibdate =      "Wed Sep 28 06:19:00 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1954:TJS,
+  author =       "Albert Einstein",
+  title =        "Tribute to {Joseph Scharl}",
+  journal =      j-NY-TIMES,
+  day =          "9",
+  month =        dec,
+  year =         "1954",
+  CODEN =        "NYTIAO",
+  ISSN =         "0362-4331 (print), 1542-667X, 1553-8095",
+  ISSN-L =       "0362-4331",
+  bibdate =      "Sat Jul 17 14:17:09 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "291",
+}
+
+@Article{Bridgman:1955:NWA,
+  author =       "P. W. Bridgman and Albert Einstein and L. Infeld and
+                 H. J. Muller and C. F. Powell and J. Rotblat and
+                 Bertrand Russell and Hideki Yukawa",
+  title =        "Nuclear War: An Appeal to Scientists and the Public",
+  journal =      "{The Lancet}",
+  volume =       "266",
+  number =       "6881",
+  pages =        "131--132",
+  day =          "16",
+  month =        jul,
+  year =         "1955",
+  DOI =          "http://dx.doi.org/10.1016/S0140-6736(55)92133-4",
+  bibdate =      "Wed Dec 14 09:37:18 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Bridgman:1955:SAA,
+  author =       "Percy W. Bridgman and Albert Einstein and Leopold
+                 Infeld and Hermann Joseph Muller and Cecil F. Powell
+                 and Bertrand Russell and Hideki Yukawa",
+  title =        "Scientists Appeal for Abolition of War",
+  journal =      j-BULL-AT-SCI,
+  volume =       "11",
+  number =       "7",
+  pages =        "236--237",
+  month =        sep,
+  year =         "1955",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Mon Sep 03 06:11:38 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprint in \cite{Russell:1963:AAW}.",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Bulletin of the Atomic Scientists",
+}
+
+@Article{Einstein:1955:ASE,
+  author =       "Albert Einstein",
+  title =        "{Albert Schweitzer} at Eighty",
+  journal =      "Christian Century",
+  volume =       "72",
+  number =       "2",
+  pages =        "42--42",
+  year =         "1955",
+  bibdate =      "Sat Jul 17 14:26:16 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "297",
+}
+
+@Unpublished{Einstein:1955:ERM,
+  author =       "Albert Einstein and Bertrand Russell",
+  title =        "The {Einstein--Russell Manifesto}",
+  year =         "1955",
+  bibdate =      "Sat Jul 17 14:23:05 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Issued in London, UK on July 9, 1955 (after Einstein's
+                 death on 18 April 1955).",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "295",
+}
+
+@Article{Einstein:1955:ESG,
+  author =       "Albert Einstein",
+  title =        "{Erinnerungen-Souvenirs}. ({German})
+                 [{Remembrances}]",
+  journal =      "Schweizerische Hochschulzeitung",
+  volume =       "28",
+  pages =        "143--153",
+  year =         "1955",
+  bibdate =      "Sat Jul 17 14:24:28 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Special volume.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "296",
+  language =     "German",
+}
+
+@InCollection{Einstein:1955:Fa,
+  author =       "Albert Einstein",
+  booktitle =    "Physics and Microphysics",
+  title =        "Foreword",
+  publisher =    pub-PANTHEON,
+  address =      pub-PANTHEON:adr,
+  bookpages =    "????",
+  pages =        "??--??",
+  year =         "1955",
+  LCCN =         "????",
+  bibdate =      "Sat Jul 17 14:18:56 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "292",
+}
+
+@InCollection{Einstein:1955:Fb,
+  author =       "Albert Einstein",
+  editor =       "William Esslinger",
+  booktitle =    "Politics and Science",
+  title =        "Foreword",
+  publisher =    pub-PHILOSOPHICAL-LIBRARY,
+  address =      pub-PHILOSOPHICAL-LIBRARY:adr,
+  bookpages =    "167",
+  pages =        "??--??",
+  year =         "1955",
+  LCCN =         "JA71 .E7",
+  bibdate =      "Sat Jul 17 14:31:03 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "299",
+}
+
+@InCollection{Einstein:1955:I,
+  author =       "Albert Einstein",
+  editor =       "Henry I. Wachtel",
+  booktitle =    "Security for all and free enterprise; a summary of the
+                 social philosophy of Josef Popper-Lynkeus [pseudonym]",
+  title =        "Introduction",
+  publisher =    pub-PHILOSOPHICAL-LIBRARY,
+  address =      pub-PHILOSOPHICAL-LIBRARY:adr,
+  bookpages =    "xi + 162",
+  pages =        "??--??",
+  year =         "1955",
+  LCCN =         "H59.P55 W3",
+  bibdate =      "Sat Jul 17 14:28:00 MDT 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "298",
+  subject =      "Popper-Lynkeus, Josef; Social problems",
+  subject-dates = "1838--1921",
+}
+
+@InCollection{Einstein:1955:MFA,
+  author =       "Albert Einstein",
+  booktitle =    "Cinquant'anni di Relativit{\`a}, 1905--1955.
+                 ({Italian}) [{Fiftieth} Anniversary of Relativity,
+                 1905--1955]",
+  title =        "Le memorie fondamentali di {Albert Einstein}.
+                 ({Italian}) [{The} Fundamental Memories of {Albert
+                 Einstein}]",
+  publisher =    "Editrice Universitaria",
+  address =      "Firenze, Italia",
+  pages =        "477--611",
+  year =         "1955",
+  MRclass =      "01.0X",
+  MRnumber =     "MR0073519 (17,446e)",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "Italian",
+}
+
+@Book{Einstein:1955:MR,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  edition =      "Fifth",
+  pages =        "vi + 169",
+  year =         "1955",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0076496 (17,907a)",
+  MRreviewer =   "A. H. Taub",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "289",
+}
+
+@Article{Einstein:1955:NFG,
+  author =       "Albert Einstein and Bruria Kaufman",
+  title =        "A new form of the general relativistic field
+                 equations",
+  journal =      j-ANN-MATH-2,
+  volume =       "62",
+  number =       "1",
+  pages =        "128--138",
+  month =        jul,
+  year =         "1955",
+  CODEN =        "ANMAAH",
+  ISSN =         "0003-486X (print), 1939-8980 (electronic)",
+  ISSN-L =       "0003-486X",
+  MRclass =      "83.0X",
+  MRnumber =     "MR0071916 (17,199h)",
+  MRreviewer =   "A. H. Taub",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "2-3;
+                 http://links.jstor.org/sici?sici=0003-486X(195507)2:62:1<128:ANFOTG>2.0.CO",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "294",
+  fjournal =     "Annals of Mathematics. Second Series",
+}
+
+@InCollection{Einstein:1955:P,
+  author =       "Albert Einstein",
+  editor =       "Jules Salvador Moch",
+  booktitle =    "Human folly: to disarm of perish?",
+  title =        "Preface",
+  publisher =    pub-GOLLANCZ,
+  address =      pub-GOLLANCZ:adr,
+  pages =        "222",
+  year =         "1955",
+  LCCN =         "UF767 .M613",
+  bibdate =      "Sat Jul 17 14:21:20 MDT 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  note =         "Translated by Edward Hyams.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "294",
+  subject =      "Nuclear warfare; Disarmament",
+}
+
+@Book{Einstein:1955:QCT,
+  author =       "Albert Einstein",
+  title =        "Quatre conf{\'e}ences sur la th{\'e}orie de la
+                 relativit{\'e} faites {\`a} {l'Universit{\'e} de
+                 Princeton}. ({French}) [Four lectures on the {Theory of
+                 Relativity}, given at {Princeton University}]",
+  publisher =    pub-GAUTHIER-VILLARS,
+  address =      pub-GAUTHIER-VILLARS:adr,
+  pages =        "99",
+  year =         "1955",
+  LCCN =         "????",
+  bibdate =      "Thu Apr 12 18:33:46 2007",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "French translation by Maurice Solovine.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Article{Einstein:1955:WTI,
+  author =       "Albert Einstein",
+  title =        "What is the Task of an International Journal?",
+  journal =      "Common Cause (Florence, Italy)",
+  volume =       "1",
+  number =       "1",
+  pages =        "3--3",
+  year =         "1955",
+  bibdate =      "Sat Jul 17 14:33:25 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "300",
+}
+
+@InCollection{Einstein:1956:ASG,
+  author =       "Albert Einstein",
+  title =        "{Autobiographische Skizze}. ({German})
+                 [{Autobiographical} sketch]",
+  crossref =     "Seelig:1956:HZD",
+  pages =        "??--??",
+  year =         "1956",
+  bibdate =      "Wed Oct 22 15:13:01 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Book{Einstein:1956:ECM,
+  author =       "Albert Einstein",
+  title =        "Sur l'{\'e}lectrodynamique des corps en mouvement.
+                 ({French}) [On the electrodynamics of moving bodies]",
+  publisher =    pub-GAUTHIER-VILLARS,
+  address =      pub-GAUTHIER-VILLARS:adr,
+  pages =        "59",
+  year =         "1956",
+  bibdate =      "Thu Apr 12 18:26:53 2007",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "French translation by Maurice Solovine.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Book{Einstein:1956:GRG,
+  author =       "Albert Einstein",
+  title =        "{Grundz{\"u}ge der Relativit{\"a}tstheorie}.
+                 ({German}) [{Essentials} of the {Theory of
+                 Relativity}]",
+  publisher =    "????",
+  address =      "????",
+  edition =      "Sixth",
+  pages =        "????",
+  year =         "1956",
+  LCCN =         "????",
+  bibdate =      "Wed Dec 14 06:37:49 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Book{Einstein:1956:ITB,
+  author =       "Albert Einstein",
+  title =        "Investigations on the theory of the {Brownian}
+                 movement",
+  publisher =    pub-DOVER,
+  address =      pub-DOVER:adr,
+  pages =        "vi + 122",
+  year =         "1956",
+  ISBN =         "0-486-60304-0",
+  ISBN-13 =      "978-0-486-60304-9",
+  LCCN =         "QC183 .E513 1956",
+  MRclass =      "80.1X",
+  MRnumber =     "MR0077443 (17,1035g)",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Edited with notes by R. F{\"u}rth, Translated by A. D.
+                 Cowper.",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1956:LMS,
+  author =       "Albert Einstein and Maurice Solovine",
+  title =        "Lettres {\`a} {Maurice Solovine}",
+  publisher =    pub-GAUTHIER-VILLARS,
+  address =      pub-GAUTHIER-VILLARS:adr,
+  pages =        "xiv + 140",
+  year =         "1956",
+  LCCN =         "QC 16 EIN",
+  bibdate =      "Sat Sep 24 13:37:21 MDT 2011",
+  bibsource =    "carmin.sudoc.abes.fr:210/ABES-Z39-PUBLIC;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "With an Introduction by Maurice Solovine.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Einstein, Albert; Correspondence; Solovine, Maurice;
+                 Physicists",
+  subject-dates = "1879--1955",
+}
+
+@Book{Einstein:1956:MLY,
+  author =       "Albert Einstein",
+  title =        "Out of my later years",
+  publisher =    pub-CITADEL-PRESS,
+  address =      pub-CITADEL-PRESS:adr,
+  pages =        "283",
+  year =         "1956",
+  LCCN =         "QC16.E5 A3 1956",
+  bibdate =      "Sat Sep 24 13:43:05 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1956:MRa,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-CHAPMAN-HALL,
+  address =      pub-CHAPMAN-HALL:adr,
+  pages =        "????",
+  year =         "1956",
+  LCCN =         "????",
+  bibdate =      "Wed Nov 23 11:43:11 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1956:MRb,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-METHUEN,
+  address =      pub-METHUEN:adr,
+  edition =      "Sixth",
+  pages =        "161",
+  year =         "1956",
+  LCCN =         "????",
+  bibdate =      "Wed Nov 23 11:43:11 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1956:MRc,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  volume =       "1921",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  edition =      "Fifth",
+  pages =        "166",
+  year =         "1956",
+  LCCN =         "QC6",
+  bibdate =      "Wed Nov 23 11:43:11 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "The Stafford Little lectures",
+  acknowledgement = ack-nhfb,
+  remark =       "Includes the relativistic theory of the non-symmetric
+                 field.",
+}
+
+@Book{Einstein:1956:TRR,
+  author =       "Albert Einstein",
+  title =        "La th{\'e}orie de la relativit{\'e} restreinte et
+                 g{\'e}n{\'e}rale: expos{\'e} {\'e}l{\'e}mentaire: La
+                 relativit{\'e} et le probl{\`e}me de l'espace",
+  publisher =    pub-GAUTHIER-VILLARS,
+  address =      pub-GAUTHIER-VILLARS:adr,
+  year =         "1956",
+  LCCN =         "????",
+  bibdate =      "Sat Sep 24 13:47:40 MDT 2011",
+  bibsource =    "carmin.sudoc.abes.fr:210/ABES-Z39-PUBLIC;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated from the German by Maurice Solovine.",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1958:CJV,
+  author =       "Albert Einstein",
+  title =        "Comment je vois le monde. ({French}) [{How} {I} see
+                 the world]",
+  publisher =    "Flammarion",
+  address =      "Paris, France",
+  pages =        "218",
+  year =         "1958",
+  LCCN =         "????",
+  bibdate =      "Fri Aug 21 08:56:56 MDT 2015",
+  bibsource =    "fsz3950.oclc.org:210/WorldCat;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated from the German, and revised and augmented
+                 by Maurice Solovine.",
+  series =       "Biblioth{\`e}que de Philosophie Scientifique",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  language =     "French",
+  subject =      "Ensayos norteamericanos; s.XX",
+}
+
+@InCollection{Einstein:1959:LS,
+  author =       "Albert Einstein",
+  title =        "The life of solitude",
+  crossref =     "Gordon:1959:ASR",
+  pages =        "??--??",
+  year =         "1959",
+  bibdate =      "Tue Oct 29 08:24:49 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1959:MI,
+  author =       "Albert Einstein",
+  title =        "A message to intellectuals",
+  crossref =     "Gordon:1959:ASR",
+  pages =        "??--??",
+  year =         "1959",
+  bibdate =      "Tue Oct 29 08:24:49 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1959:PMC,
+  author =       "Albert Einstein",
+  title =        "Portrait of {Madame Curie}",
+  crossref =     "Gordon:1959:ASR",
+  pages =        "??--??",
+  year =         "1959",
+  bibdate =      "Tue Oct 29 08:24:49 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1959:SP,
+  author =       "Albert Einstein",
+  title =        "Self-portrait",
+  crossref =     "Gordon:1959:ASR",
+  pages =        "??--??",
+  year =         "1959",
+  bibdate =      "Tue Oct 29 08:24:49 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1959:SSA,
+  author =       "Albert Einstein",
+  title =        "[{Schopenhauer}, science, and art]",
+  journal =      j-BULL-AT-SCI,
+  volume =       "15",
+  number =       "2",
+  pages =        "85--85",
+  month =        feb,
+  year =         "1959",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Sat Sep 28 07:23:08 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Bulletin of the Atomic Scientists",
+  remark =       "One-paragraph quote.",
+}
+
+@InCollection{Einstein:1959:WWM,
+  author =       "Albert Einstein",
+  title =        "The world we make. Knowledge comes: Science and
+                 society",
+  crossref =     "Gordon:1959:ASR",
+  pages =        "??--??",
+  year =         "1959",
+  bibdate =      "Tue Oct 29 08:24:49 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1960:EPa,
+  author =       "Albert Einstein and Otto Nathan and Heinz Norden",
+  title =        "{Einstein} on peace",
+  publisher =    pub-METHUEN,
+  address =      pub-METHUEN:adr,
+  pages =        "xvi + 704",
+  year =         "1960",
+  LCCN =         "JX 1952.E44 NAT",
+  bibdate =      "Sat Sep 24 13:50:00 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 innopac.wits.ac.za:210/INNOPAC",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Peace",
+}
+
+@Book{Einstein:1960:EPb,
+  author =       "Albert Einstein",
+  title =        "{Einstein} on peace",
+  publisher =    pub-SIMON-SCHUSTER,
+  address =      pub-SIMON-SCHUSTER:adr,
+  pages =        "xvi + 704",
+  year =         "1960",
+  bibdate =      "Tue Dec 20 18:17:45 MST 2005",
+  bibsource =    "amicus.nlc-bnc.ca:210/NL;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Peace",
+}
+
+@Book{Einstein:1960:EPc,
+  author =       "Albert Einstein and Otto Nathan and Heinz Norden",
+  title =        "{Einstein} on peace",
+  publisher =    pub-SCHOCKEN-BOOKS,
+  address =      pub-SCHOCKEN-BOOKS:adr,
+  pages =        "xvi + 704",
+  year =         "1960",
+  LCCN =         "JZ 5574 EIN",
+  bibdate =      "Sat Sep 24 13:50:00 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 innopac.wits.ac.za:210/INNOPAC",
+  note =         "Edited by Otto Nathan and Heinz Norden. Preface by
+                 Bertrand Russell.",
+  acknowledgement = ack-nhfb,
+  author-dates = "Albert Einstein (1879--1955); Otto Nathan
+                 (1893--1987); Heinz Norden (1905--1978)",
+  remark =       "Revised German edition published in 1975 under title
+                 {\em {\"U}ber den Frieden}.",
+  subject =      "Peace",
+}
+
+@Book{Einstein:1960:FTO,
+  author =       "Albert Einstein",
+  title =        "Field theories, old and new",
+  publisher =    "Readex Microprint",
+  address =      "New York, NY, USA",
+  pages =        "????",
+  year =         "1960",
+  LCCN =         "QC 173.7 EIN",
+  bibdate =      "Sat Sep 24 13:50:00 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 innopac.wits.ac.za:210/INNOPAC",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Reprint of an article from the New York Times,
+                 February 3, 1929.",
+  subject =      "field theory (physics)",
+}
+
+@Book{Einstein:1960:RSG,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: the special and the general theory: a
+                 popular exposition",
+  publisher =    pub-METHUEN,
+  address =      pub-METHUEN:adr,
+  edition =      "15th",
+  pages =        "ix + 165",
+  year =         "1960",
+  LCCN =         "????",
+  bibdate =      "Sat Sep 24 13:50:00 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 innopac.wits.ac.za:210/INNOPAC",
+  note =         "Authorised translation by Robert W. Lawson.",
+  series =       "University paperbacks.",
+  acknowledgement = ack-nhfb,
+  subject =      "Relativity (Physics)",
+}
+
+@Book{Einstein:1961:EP,
+  author =       "Albert Einstein and Leopold Infeld",
+  title =        "The evolution of physics",
+  publisher =    pub-CAMBRIDGE,
+  address =      pub-CAMBRIDGE:adr,
+  edition =      "Second",
+  pages =        "302",
+  year =         "1961",
+  ISBN =         "0-521-08371-0, 0-521-09687-1",
+  ISBN-13 =      "978-0-521-08371-3, 978-0-521-09687-4",
+  LCCN =         "QC 7 EIN",
+  bibdate =      "Sat Sep 24 13:50:00 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 innopac.wits.ac.za:210/INNOPAC",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "physics; history; Relativity (physics); quantum
+                 theory",
+}
+
+@Book{Einstein:1961:EPG,
+  author =       "Albert Einstein and Leopold Infeld",
+  title =        "The evolution of physics: the growth of ideas from
+                 early concepts to {Relativity} and quanta",
+  publisher =    pub-SIMON-SCHUSTER,
+  address =      pub-SIMON-SCHUSTER:adr,
+  pages =        "xvi + 302",
+  year =         "1961",
+  LCCN =         "QC7 .E5 1961",
+  bibdate =      "Mon Oct 9 06:48:08 MDT 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  series =       "An Essandess paperback",
+  acknowledgement = ack-nhfb,
+  author-dates = "Albert Einstein (1879--1955); Leopold Infeld
+                 (1898--1968)",
+  remark =       "Reprint of 1938 edition.",
+  subject =      "Physics; History; Relativity (physics); Quantum
+                 theory",
+}
+
+@Book{Einstein:1961:RSGa,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: the {Special} and the {General Theory}",
+  publisher =    pub-THREE-RIVERS,
+  address =      pub-THREE-RIVERS:adr,
+  pages =        "xiii + 188",
+  year =         "1961",
+  LCCN =         "????",
+  bibdate =      "Mon Nov 21 05:53:26 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 library.ox.ac.uk:210/ADVANCE",
+  note =         "Authorized translation by Robert W. Lawson.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+}
+
+@Book{Einstein:1961:RSGb,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: the {Special} and the {General Theory}",
+  publisher =    pub-CROWN-TRADE-PAPERBACKS,
+  address =      pub-CROWN-TRADE-PAPERBACKS:adr,
+  edition =      "Second",
+  pages =        "xiii + 188",
+  year =         "1961",
+  ISBN =         "0-517-88441-0",
+  ISBN-13 =      "978-0-517-88441-6",
+  LCCN =         "QC173.55 .E384513 1961",
+  bibdate =      "Mon Nov 21 05:53:26 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 library.ox.ac.uk:210/ADVANCE",
+  note =         "Authorized translation by Robert W. Lawson.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+}
+
+@InCollection{Einstein:1963:EL,
+  author =       "Albert Einstein",
+  title =        "The {Einstein} Letter",
+  crossref =     "Grodzins:1963:AAS",
+  pages =        "11--12",
+  year =         "1963",
+  bibdate =      "Mon Sep 03 05:56:24 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1963:EP,
+  author =       "Albert Einstein and Otto Nathan and Heinz Norden",
+  title =        "{Einstein} on peace",
+  publisher =    pub-METHUEN,
+  address =      pub-METHUEN:adr,
+  pages =        "xvi + 704",
+  year =         "1963",
+  LCCN =         "JX 1952.E44 NAT",
+  bibdate =      "Sat Sep 24 13:50:00 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 innopac.wits.ac.za:210/INNOPAC",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Peace",
+}
+
+@InCollection{Einstein:1963:ER,
+  author =       "Albert Einstein",
+  title =        "{Einstein} replies",
+  crossref =     "Grodzins:1963:AAS",
+  pages =        "130--134",
+  year =         "1963",
+  bibdate =      "Mon Sep 03 05:56:24 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reply to \cite{Vavilov:1963:AES}. Reprint of
+                 \cite{Einstein:1948:RSS}.",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Russell:1963:AAW,
+  author =       "Bertrand Russell and Albert Einstein",
+  title =        "An Appeal for the Abolition of War",
+  crossref =     "Grodzins:1963:AAS",
+  pages =        "539--541",
+  year =         "1963",
+  bibdate =      "Mon Sep 03 05:56:24 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprint of \cite{Bridgman:1955:SAA}.",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1964:GHD,
+  author =       "A. E{\u\i}n{\v{s}}te{\u\i}n",
+  title =        "On {Galileo} and his {{\em Dialogue}}",
+  journal =      "Voprosy Istor. Estest. i Tehn. No.",
+  volume =       "16",
+  pages =        "29--33",
+  year =         "1964",
+  MRclass =      "01.20",
+  MRnumber =     "MR0173613 (30 \#3824)",
+  MRreviewer =   "C. J. Scriba",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "Russian",
+}
+
+@Book{Einstein:1964:QCT,
+  author =       "Albert Einstein",
+  title =        "Quatre conf{\'e}ences sur la th{\'e}orie de la
+                 relativit{\'e} faites {\`a} {l'Universit{\'e} de
+                 Princeton}. ({French}) [Four lectures on the {Theory of
+                 Relativity}, given at {Princeton University}]",
+  publisher =    pub-GAUTHIER-VILLARS,
+  address =      pub-GAUTHIER-VILLARS:adr,
+  pages =        "ii + 98",
+  year =         "1964",
+  LCCN =         "????",
+  bibdate =      "Thu Apr 12 18:33:46 2007",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "French translation by Maurice Solovine.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Book{Einstein:1965:MR,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    "Oxford Book, Inc.",
+  address =      "Calcutta, India",
+  pages =        "161",
+  year =         "1965",
+  LCCN =         "????",
+  bibdate =      "Wed Nov 23 13:26:16 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  remark =       "Appendix II has been rewritten. The text of the first
+                 edition was translated by Edwin Plimpton Adams, the
+                 first appendix by Ernst G. Straus and the second
+                 appendix by Sonja Bargmann. This edition was first
+                 published in 1956.",
+}
+
+@Book{Einstein:1966:EPE,
+  author =       "Albert Einstein and Leopold Infeld",
+  title =        "The evolution of physics from early concepts to
+                 {Relativity} and quanta",
+  publisher =    pub-SIMON-SCHUSTER,
+  address =      pub-SIMON-SCHUSTER:adr,
+  pages =        "xvi + 302",
+  year =         "1966",
+  ISBN =         "0-671-20156-5",
+  ISBN-13 =      "978-0-671-20156-2",
+  LCCN =         "QC7 .E5 1961",
+  bibdate =      "Mon Oct 9 06:48:08 MDT 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  series =       "A Touchstone book",
+  acknowledgement = ack-nhfb,
+  author-dates = "Albert Einstein (1879--1955); Leopold Infeld
+                 (1898--1968)",
+  remark =       "Reprint of 1938 and 1961 editions.",
+  subject =      "Physics; History; Relativity (physics); Quantum
+                 theory",
+}
+
+@Book{Einstein:1967:MRa,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-CHAPMAN-HALL,
+  address =      pub-CHAPMAN-HALL:adr,
+  edition =      "Sixth",
+  pages =        "xiv + 161",
+  year =         "1967",
+  LCCN =         "QC173.55",
+  bibdate =      "Wed Nov 23 11:43:11 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  remark =       "With a new foreword by W. H. McCrea.",
+}
+
+@Book{Einstein:1967:MRb,
+  author =       "Albert Einstein and Edwin P. (Edwin Plimpton) Adams",
+  title =        "The Meaning of {Relativity}",
+  publisher =    "Science Paperbacks",
+  address =      "London, UK",
+  pages =        "xiv + 161",
+  year =         "1967",
+  LCCN =         "QC173.55",
+  bibdate =      "Wed Nov 23 11:43:11 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  remark =       "Appendix II has been rewritten. The text of the first
+                 edition was translated by Edwin Plimpton Adams, the
+                 first appendix by Ernst G. Straus and the second
+                 appendix by Sonja Bargmann. This edition was first
+                 published in 1956.",
+}
+
+@InCollection{Einstein:1967:QTR,
+  author =       "Albert Einstein",
+  title =        "On the Quantum Theory of Radiation",
+  crossref =     "vanderWaerden:1967:SQM",
+  pages =        "63--77",
+  year =         "1967",
+  bibdate =      "Mon Oct 24 17:02:49 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1968:BBG,
+  author =       "Albert Einstein and Arnold Sommerfeld",
+  title =        "{Briefwechsel. 60 Briefe aus dem goldenen Zeitalter
+                 der modernen Physik}. ({German}) [{Letter} exchanges:
+                 60 letters from the {Golden Age} of modern physics]",
+  publisher =    "Schwabe",
+  address =      "Stuttgart, Germany and Basel, Switzerland",
+  pages =        "126 + 2",
+  year =         "1968",
+  LCCN =         "QC16.E5 A43",
+  bibdate =      "Tue Jul 06 10:18:17 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "With commentary by Armin Hermann.",
+  acknowledgement = ack-nhfb,
+  author-dates = "Albert Einstein (1879--1955), Arnold Sommerfeld
+                 (1868--1951)",
+  language =     "German",
+}
+
+@Book{Einstein:1968:EP,
+  author =       "Albert Einstein and Otto Nathan and Heinz Norden",
+  title =        "{Einstein} on peace",
+  publisher =    pub-SCHOCKEN-BOOKS,
+  address =      pub-SCHOCKEN-BOOKS:adr,
+  pages =        "xvi + 704",
+  year =         "1968",
+  LCCN =         "JZ 5574 EIN",
+  bibdate =      "Sat Sep 24 13:50:00 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 innopac.wits.ac.za:210/INNOPAC",
+  note =         "Edited by Otto Nathan and Heinz Norden. Preface by
+                 Bertrand Russell.",
+  acknowledgement = ack-nhfb,
+  author-dates = "Albert Einstein (1879--1955); Otto Nathan
+                 (1893--1987); Heinz Norden (1905--1978)",
+  remark =       "Revised German edition published in 1975 under title
+                 {\em {\"U}ber den Frieden}.",
+  subject =      "Peace",
+}
+
+@InCollection{Einstein:1969:F,
+  author =       "Albert Einstein",
+  editor =       "Max Jammer",
+  booktitle =    "Concepts of Space: the history of theories of space in
+                 physics",
+  title =        "Foreword",
+  publisher =    pub-HARVARD,
+  address =      pub-HARVARD:adr,
+  edition =      "Second",
+  bookpages =    "xv + 221",
+  pages =        "??--??",
+  year =         "1969",
+  LCCN =         "QC6 .J3",
+  bibdate =      "Sat Jul 17 14:04:32 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See other editions
+                 \cite{Einstein:1954:F,Einstein:1993:F}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "288b",
+}
+
+@Book{Einstein:1969:MR,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  volume =       "1921",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  edition =      "Fifth",
+  pages =        "166",
+  year =         "1969",
+  LCCN =         "QC173.55",
+  bibdate =      "Wed Nov 23 11:43:11 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "The Stafford Little lectures",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1970:MLY,
+  author =       "Albert Einstein",
+  title =        "Out of my later years",
+  publisher =    pub-GREENWOOD,
+  address =      pub-GREENWOOD:adr,
+  pages =        "283",
+  year =         "1970",
+  ISBN =         "0-8371-2086-1",
+  ISBN-13 =      "978-0-8371-2086-7",
+  LCCN =         "QC16.E5 A3 1970",
+  bibdate =      "Fri Nov 25 11:26:14 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  remark =       "Revised reprint of 1950 edition.",
+}
+
+@InCollection{Einstein:1970:RCE,
+  author =       "Albert Einstein",
+  title =        "Remarks Concerning the Essays Brought Together in this
+                 Co-Operative Volume",
+  crossref =     "Schilpp:1970:AEP",
+  pages =        "665--688",
+  year =         "1970",
+  bibdate =      "Wed Nov 23 11:37:44 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1970:SD,
+  author =       "Albert Einstein",
+  editor =       "Otto {Forst de Battaglia}",
+  booktitle =    "Dictatorship on its trial, by eminent leaders of
+                 modern thought",
+  title =        "Science and Dictatorship",
+  publisher =    "Books for Libraries Press",
+  address =      "Freeport, NY, USA",
+  bookpages =    "389",
+  pages =        "??--??",
+  year =         "1970",
+  ISBN =         "0-8369-1607-7",
+  ISBN-13 =      "978-0-8369-1607-2",
+  LCCN =         "D107 .F65 1970",
+  bibdate =      "Sat Jul 17 09:02:04 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  note =         "Translated by Huntley Paterson. With an introduction
+                 by Winston S. Churchill.",
+  series =       "Essay index reprint series",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "163",
+  remark =       "English translation of \cite{Einstein:1930:SD}.
+                 Einstein's contribution is only two lines.",
+}
+
+@Book{Einstein:1971:MLY,
+  author =       "Albert Einstein",
+  title =        "Out of my later years",
+  publisher =    "Bonanza Books",
+  address =      "New York, NY, USA",
+  pages =        "viii + 282",
+  year =         "1971",
+  LCCN =         "QC16.E5 A3 1989",
+  bibdate =      "Tue Jul 06 10:35:25 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1972:C,
+  author =       "Albert Einstein and Mich{\`e}le Angelo Besso",
+  title =        "Correspondance 1903--1955",
+  publisher =    "Hermann",
+  address =      "Paris, France",
+  pages =        "lxiii + 559",
+  year =         "1972",
+  LCCN =         "QC 16 .E5 A4212",
+  MRclass =      "01A75 (01A70)",
+  MRnumber =     "MR0389516 (52 \#10347)",
+  bibdate =      "Mon Dec 12 11:02:26 2011",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/d/dirac-p-a-m.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Traduction, notes et introduction de Pierre Speziali,
+                 Avec des notes aux passages traitant de la
+                 relativit{\'e}, par Marie-Antoinette Tonnelat,
+                 Collection Histoire de la Pens{\'e}e, 17",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Book{Einstein:1972:GM,
+  author =       "Alfred Einstein",
+  title =        "Greatness in music",
+  publisher =    "Da Capo Press",
+  address =      "New York, NY, USa",
+  pages =        "vii + 287",
+  year =         "1972",
+  ISBN =         "0-306-71441-8",
+  ISBN-13 =      "978-0-306-71441-2",
+  LCCN =         "ML3847 .E4813 1972",
+  bibdate =      "Mon Oct 10 08:30:06 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  series =       "Da Capo Press music reprint series",
+  acknowledgement = ack-nhfb,
+  author-dates = "1880--1952",
+  remark =       "Translation by C{\'e}sar Saerchinger of Gr{\"o}sse in
+                 der Musik. Reprint of the 1941 edition published by
+                 Oxford University Press, New York.",
+  subject =      "Music; Philosophy and aesthetics; Genius",
+}
+
+@Article{Einstein:1972:JKA,
+  author =       "Albert Einstein and I. N. Vesselovsky and Yu. A. Belyj
+                 and R. Plechkaitis and I. M. Rabinovich and Yu. Kh.
+                 Kopelevich and M. E. Glinka and E. S. Shchukina",
+  title =        "{Johann Kepler} (to the 400th anniversary since {J.
+                 Kepler}'s birthday)",
+  journal =      "Istoriko-Astronomicheskie Issledovaniya",
+  volume =       "11",
+  number =       "??",
+  pages =        "15--177",
+  year =         "1972",
+  ISSN =         "0234-8632",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "0408.01008",
+  acknowledgement = ack-nhfb,
+  classmath =    "*01A40 Mathematics in the 15th and 16th centuries,
+                 Renaissance 01A45 Mathematics in the 17th century 01A70
+                 Biographies, obituaries, personalia, bibliographies",
+  language =     "Russian",
+}
+
+@Book{Einstein:1972:WKG,
+  author =       "Albert Einstein and Sigmund Freud and Isaac Asimov",
+  title =        "{Warum Krieg?}. ({German}) [{Why} War?]",
+  volume =       "28",
+  publisher =    "Diogenes-Verlag",
+  address =      "Z{\"u}rich, Switzerland",
+  pages =        "62",
+  year =         "1972",
+  ISBN =         "3-257-20028-5",
+  ISBN-13 =      "978-3-257-20028-7",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 10 08:11:31 MDT 2011",
+  bibsource =    "fsz3950.oclc.org:210/WorldCat;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "Diogenes-Taschenbuch",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Book{Einstein:1973:IO,
+  author =       "Albert Einstein",
+  title =        "Ideas and Opinions",
+  publisher =    "Souvenir Press",
+  address =      "London, UK",
+  pages =        "378",
+  year =         "1973",
+  ISBN =         "0-285-64724-5",
+  ISBN-13 =      "978-0-285-64724-4",
+  LCCN =         "AC35 .E48 1973",
+  bibdate =      "Wed Nov 23 11:44:31 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Based on {\em Mein Weltbild}, edited by Carl Seelig,
+                 and other sources. New translations and revisions by
+                 Sonja Bargmann.",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1974:MR,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  edition =      "Fifth",
+  pages =        "166",
+  year =         "1974",
+  ISBN =         "0-691-02352-2",
+  ISBN-13 =      "978-0-691-02352-6",
+  LCCN =         "QC6 .E5 1979",
+  bibdate =      "Wed Nov 23 11:39:22 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1975:PSH,
+  author =       "Albert Einstein",
+  title =        "12. The Problem of the Specific Heats",
+  crossref =     "Mehra:1975:SCP",
+  pages =        "61--72",
+  year =         "1975",
+  bibdate =      "Thu Aug 23 14:03:54 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1976:GM,
+  author =       "Alfred Einstein",
+  title =        "Greatness in music",
+  publisher =    "Da Capo Press",
+  address =      "New York, NY, USA",
+  pages =        "vii + 287",
+  year =         "1976",
+  ISBN =         "0-306-80046-2",
+  ISBN-13 =      "978-0-306-80046-7",
+  LCCN =         "ML3847 .E4813 1976",
+  bibdate =      "Mon Oct 10 08:31:55 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  series =       "A Da Capo paperback",
+  acknowledgement = ack-nhfb,
+  author-dates = "1880--1952",
+  remark =       "Translation by C{\'e}sar Saerchinger of Gr{\"o}sse in
+                 der Musik. Reprint of the 1941 edition published by
+                 Oxford University Press, New York.",
+  subject =      "Music; Philosophy and aesthetics; Genius",
+}
+
+@Book{Einstein:1976:QCT,
+  author =       "Albert Einstein",
+  title =        "Quatre conf{\'e}rences sur la th{\'e}orie de la
+                 relativit{\'e} faites {\`a} l'{Universit}{\'e} de
+                 {Princeton}. ({French}) [{Four} conferences on the
+                 {Theory of Relativity} held at {Princeton
+                 University}]",
+  publisher =    pub-GAUTHIER-VILLARS,
+  address =      pub-GAUTHIER-VILLARS:adr,
+  pages =        "ii + 96",
+  year =         "1976",
+  ISBN =         "2-04-002618-5",
+  ISBN-13 =      "978-2-04-002618-9",
+  MRclass =      "01A75 (83.00)",
+  MRnumber =     "MR0532669 (58 \#27143)",
+  bibdate =      "Mon Dec 12 11:02:35 2011",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/d/dirac-p-a-m.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated from the German by Maurice Solovine,
+                 Reprinting of the 1925 original, Collection ``Discours
+                 de la M{\'e}thode''",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Book{Einstein:1976:TRR,
+  author =       "Albert Einstein",
+  title =        "La th{\'e}orie de la relativit{\'e} restreinte et
+                 g{\'e}n{\'e}rale. ({French}) [{The Special and General
+                 Theory of Relativity}]",
+  publisher =    pub-GAUTHIER-VILLARS,
+  address =      pub-GAUTHIER-VILLARS:adr,
+  pages =        "vi + 177",
+  year =         "1976",
+  ISBN =         "2-04-002566-9",
+  ISBN-13 =      "978-2-04-002566-3",
+  MRclass =      "01A75 (83.01)",
+  MRnumber =     "MR0532667 (58 \#27142)",
+  bibdate =      "Mon Dec 12 11:02:46 2011",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/d/dirac-p-a-m.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Expos{\'e} {\'e}l{\'e}mentaire, La relativit{\'e} et
+                 le probl{\`e}me de l'espace, Translated from the German
+                 by Maurice Solovine, New printing, Collection
+                 ``Discours de la M{\'e}thode''",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Book{Einstein:1977:RSG,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: the {Special} and the {General Theory}:
+                 a popular exposition",
+  volume =       "10",
+  publisher =    pub-METHUEN,
+  address =      pub-METHUEN:adr,
+  pages =        "x + 165",
+  year =         "1977",
+  ISBN =         "0-416-67600-6",
+  ISBN-13 =      "978-0-416-67600-6",
+  LCCN =         "????",
+  bibdate =      "Mon Nov 21 05:53:26 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Authorized translation by Robert W. Lawson. Seventh
+                 reprinting.",
+  series =       "University paperbacks",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Original title: {\"U}ber die spezielle und allgemeine
+                 Relativit{\"a}tstheorie.",
+}
+
+@InCollection{Einstein:1977:WSG,
+  author =       "Albert Einstein",
+  editor =       "Max Planck",
+  booktitle =    "Where is Science Going?",
+  title =        "Prologue and Epilogue: a {Socratic} Dialogue",
+  publisher =    "AMS Press",
+  address =      "New York, NY, USA",
+  pages =        "221",
+  year =         "1977",
+  ISBN =         "0-404-14696-1",
+  ISBN-13 =      "978-0-404-14696-2",
+  LCCN =         "Q175 .P57 1977",
+  bibdate =      "Sat Jul 17 10:39:02 MDT 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+  author-dates = "1858--1947",
+  Calaprice-number = "181",
+  remark =       "Reprint of \cite{Einstein:1932:PES}.",
+  subject =      "Science; Philosophy; Physics; Causation; Free will and
+                 determinism",
+}
+
+@Book{Einstein:1978:GM,
+  author =       "Alfred Einstein",
+  title =        "Greatness in music",
+  publisher =    "Scholarly Press",
+  address =      "St. Clair Shores, MI, USA",
+  pages =        "vii + 287",
+  year =         "1978",
+  ISBN =         "0-403-01549-9",
+  ISBN-13 =      "978-0-403-01549-8",
+  LCCN =         "ML3847 .E4813 1978",
+  bibdate =      "Mon Oct 10 08:31:55 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+  author-dates = "1880--1952",
+  remark =       "Translation by C{\'e}sar Saerchinger of Gr{\"o}sse in
+                 der Musik. Reprint of the 1941 edition published by
+                 Oxford University Press, New York.",
+  subject =      "Music; Philosophy and aesthetics; Genius",
+}
+
+@Book{Einstein:1978:RSG,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: the {Special} and the {General Theory}:
+                 a popular exposition",
+  publisher =    "Wings Books",
+  address =      "New York, NY, USA",
+  pages =        "xiii + 188",
+  year =         "1978",
+  ISBN =         "0-517-02530-2 (paperback), 0-517-02961-8 (hardcover)",
+  ISBN-13 =      "978-0-517-02530-7 (paperback), 978-0-517-02961-9
+                 (hardcover)",
+  LCCN =         "????",
+  bibdate =      "Mon Nov 21 05:53:26 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Authorized translation by Robert W. Lawson.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Reprint of fifteenth edition (1952).",
+  tableofcontents = "Part I. The Special Theory of Relativity. Physical
+                 meaning of geometrical propositions \\
+                 The system of coordinates \\
+                 Space and time in classical mechanics \\
+                 The Galileian system of coordinates \\
+                 The principle of relativity \\
+                 The theorem of the addition of velocities employed in
+                 classical mechanics \\
+                 The apparent incompatibility of the law of propagation
+                 of light with the principle of relativity \\
+                 On the idea of time in physics \\
+                 The relativity of simultaneity \\
+                 On the relativity of the conception of distance \\
+                 The lorentz transformation \\
+                 The behavior of measuring-rods and clocks in motionPart
+                 II. The General Theory of Relativity. Special and
+                 general principle of relativity \\
+                 The gravitational field \\
+                 The equality of inertial and gravitational mass as an
+                 argument for the general postulate of relativity \\
+                 In what respect are the foundation of classical
+                 mechanics and of the special theory of relativity
+                 unsatisfactory? \\
+                 A few inferences from the general principle of
+                 relativity \\
+                 Behavior of clocks and measuring rods on a rotating
+                 body of reference \\
+                 Euclidean and noneuclidean continuum \\
+                 Gaussian coordinates \\
+                 The space--time continuum of the special theory of
+                 relativity ocnsidered as a euclidean continuum \\
+                 The space--time continuum of the general theory of
+                 relativity is not a euclidean continuum \\
+                 Exact formation of the general principle of relativity
+                 \\
+                 The solution of the problem of gravitation on the basis
+                 of the general principle of relativity \\
+                 Part III. Considerations on the Universe as a Whole.
+                 Cosmological difficulties of Newton's Theory \\
+                 The possibility of a ``finite'' and yet ``unbounded''
+                 universe \\
+                 The structure of space according to the general theory
+                 of relativity",
+}
+
+@Book{Cartan:1979:LAP,
+  author =       "{\'E}lie Joseph Cartan and Albert Einstein",
+  title =        "Letters on absolute parallelism, 1929--1932",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "xvii + 235 + 2 + (loose erratum)",
+  year =         "1979",
+  ISBN =         "0-691-08229-4",
+  ISBN-13 =      "978-0-691-08229-5",
+  LCCN =         "QC15 .C27 1979",
+  MRclass =      "01A60 (01A70 53-03 83-03)",
+  MRnumber =     "MR543192 (80m:01030)",
+  MRreviewer =   "H. Treder",
+  bibdate =      "Mon Dec 12 11:03:13 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Original text with English translation by Jules Leroy
+                 and Jim Ritter. Edited by Robert Debever.",
+  acknowledgement = ack-nhfb,
+  remark =       "At head of title: Princeton University Press and
+                 Academie royale de Belgique. In German and French, with
+                 English translation.",
+  subject-dates = "Elie Joseph Cartan (1869--1951); Albert Einstein
+                 (1879--1955)",
+}
+
+@Book{Cartan:1979:LPA,
+  author =       "{\'E}lie Cartan and Albert Einstein",
+  title =        "Lettres sur le parall{\'e}lisme absolu, 1929--1932.
+                 Textes originaux, traduction anglaise par Jules Leroy
+                 et Jim Ritter. Publi{\'e}s par Robert Debever.
+                 ({French}) [Letters on absolute parallelism,
+                 1929--1932. Original texts and {English} translation by
+                 {Jules Leroy} and {Jim Ritter}. {Published} by {Robert
+                 Debever}]",
+  publisher =    pub-PRINCETON # " and " # pub-ACAD-ROY-BELG,
+  address =      pub-PRINCETON:adr # " and " # pub-ACAD-ROY-BELG:adr,
+  pages =        "xvii + 235",
+  year =         "1979",
+  bibdate =      "Wed Nov 23 14:13:37 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  ZMnumber =     "0592.01014",
+  acknowledgement = ack-nhfb,
+  classmath =    "{*01A60 Mathematics in the 20th century 83-03
+                 Historical (Relativity) 01-02 Research monographs
+                 (history)}",
+  keywords =     "Berlin-Academy; compatibility; E. Cartan; field
+                 theory; of Sciences; symmetry",
+  language =     "French",
+}
+
+@Book{Einstein:1979:AN,
+  author =       "Albert Einstein",
+  title =        "Autobiographical notes",
+  publisher =    pub-OPEN-COURT,
+  address =      pub-OPEN-COURT:adr,
+  edition =      "Centennial",
+  pages =        "v + 89 + 1",
+  year =         "1979",
+  ISBN =         "0-87548-352-6",
+  ISBN-13 =      "978-0-87548-352-8",
+  MRclass =      "01A70 (01A60 83-03)",
+  MRnumber =     "MR529428 (80h:01030)",
+  MRreviewer =   "H. Treder",
+  bibdate =      "Mon Dec 12 11:03:21 2011",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/d/dirac-p-a-m.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated from the German and edited by Paul Arthur
+                 Schilpp",
+  acknowledgement = ack-nhfb,
+  remark =       "German text and English translation on opposite
+                 pages.",
+}
+
+@Article{Einstein:1979:AWW,
+  author =       "Albert Einstein",
+  title =        "After {World War II}",
+  journal =      j-BULL-AT-SCI,
+  volume =       "35",
+  number =       "3",
+  pages =        "35--35",
+  month =        mar,
+  year =         "1979",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Mon Sep 19 09:57:56 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Special issue on Einstein and peace.",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Bulletin of the Atomic Scientists",
+  remark =       "Reprinted from The Bulletin, October 1952,
+                 of an address at the Fifth Nobel Anniversary Dinner at
+                 the Hotel Astor, New York City, 10 December 1945.",
+}
+
+@Book{Einstein:1979:FGA,
+  author =       "Albert Einstein and Otto Hahn and Lise Meitner and Max
+                 von Laue and others",
+  title =        "{Feier der 100. Geburtstage von Albert Einstein, Otto
+                 Hahn, Lise Meitner, Max von Laue}. ({German})
+                 [{Celebration} of the 100th Birthdays of {Albert
+                 Einstein}, {Otto Hahn}, {Lise Meitner}, {Max von
+                 Laue}]",
+  publisher =    "Wissenschaftliche Verlagsgesellschaft",
+  address =      "Stuttgart, West Germany",
+  pages =        "99",
+  year =         "1979",
+  ISBN =         "3-8047-0594-4",
+  ISBN-13 =      "978-3-8047-0594-4",
+  LCCN =         "QC15 .F44",
+  bibdate =      "Mon Jul 15 06:42:13 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  series =       "Paperback der Zeitschrift Naturwissenschaftliche
+                 Rundschau",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  subject =      "Physicists; Germany (West); Biography; Einstein,
+                 Albert; Hahn, Otto; Meitner, Lise; Laue, Max von",
+  subject-dates = "1879--1955; 1879--1968; 1878--1968; 1879--1960",
+}
+
+@Article{Einstein:1979:LP,
+  author =       "A. Einstein",
+  title =        "{Paul Langevin}",
+  journal =      "Pens{\'e}e",
+  volume =       "??",
+  number =       "205",
+  pages =        "74--75",
+  month =        "????",
+  year =         "1979",
+  ISSN =         "0031-4773",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1979:LWP,
+  author =       "Albert Einstein",
+  title =        "Letter to {W. Pauli, 19 September 1938, AE 19-175}",
+  crossref =     "Hermann:1979:WPW",
+  volume =       "2",
+  pages =        "??--??",
+  year =         "1979",
+  bibdate =      "Sat Oct 28 17:24:54 2006",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/p/pauli-wolfgang.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1979:MOS,
+  author =       "Albert Einstein",
+  title =        "On the moral obligation of the scientist",
+  journal =      j-BULL-AT-SCI,
+  volume =       "35",
+  number =       "3",
+  pages =        "1--1",
+  month =        mar,
+  year =         "1979",
+  CODEN =        "BASIAP",
+  ISSN =         "0096-3402 (print), 1938-3282 (electronic)",
+  ISSN-L =       "0096-3402",
+  bibdate =      "Mon Sep 19 09:57:56 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/bullatsci.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Special issue on Einstein and peace.",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Bulletin of the Atomic Scientists",
+  remark =       "Letter of October 1952, reprinted from The
+                 Bulletin, June 1955.",
+}
+
+@Article{Einstein:1979:RPG,
+  author =       "Albert Einstein",
+  title =        "{Zum Relativit{\"a}ts-Problem}. ({German}) [{On} the
+                 {Relativity} Problem]",
+  journal =      j-SCIENTIA-MILAN,
+  volume =       "114",
+  number =       "1-4",
+  pages =        "5--28",
+  year =         "1979",
+  CODEN =        "SCIMAI",
+  ISSN =         "0036-8687 (print), 1825-4373 (electronic)",
+  ISSN-L =       "0036-8687",
+  MRclass =      "01A75 (83-03)",
+  MRnumber =     "MR558511 (82a:01054)",
+  bibdate =      "Wed Nov 23 14:06:17 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "With a French translation by M. E. Philippi.",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Scientia. Rivista Internazionale di Sintesi
+                 Scientifica",
+  journal-URL =  "http://amshistorica.unibo.it/6",
+  language =     "German",
+  xxpages =      "5--16",
+}
+
+@Article{Einstein:1979:SD,
+  author =       "A. Einstein",
+  title =        "Scientists' Dilemma",
+  journal =      "UNESCO Courier",
+  volume =       "??",
+  number =       "5",
+  pages =        "31--32",
+  month =        "????",
+  year =         "1979",
+  ISSN =         "0041-5278",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1980:GMG,
+  author =       "Albert Einstein",
+  title =        "Gr{\"o}{\ss}e in der Musik. ({German}) [Greatness in
+                 Music]",
+  publisher =    "Deutscher Taschenbuch Verlag",
+  address =      "M{\"u}nchen, West Germany",
+  pages =        "173",
+  year =         "1980",
+  ISBN =         "3-423-01609-4, 3-7618-1609-X",
+  ISBN-13 =      "978-3-423-01609-4, 978-3-7618-1609-7",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 10 08:40:44 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Book{Einstein:1981:MR,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    "Franklin Library",
+  address =      "Franklin Center, PA, USA",
+  edition =      "Fifth limited",
+  pages =        "208",
+  year =         "1981",
+  LCCN =         "????",
+  bibdate =      "Wed Nov 23 11:43:11 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  remark =       "The text of the first edition was translated by Edwin
+                 Plimpton Adams.",
+}
+
+@Book{Einstein:1982:BGC,
+  author =       "Albert Einstein and Max Born",
+  title =        "Briefwechsel: 1916--1955. ({German})
+                 [{Correspondence}: 1916--1955]",
+  publisher =    "Edition Erbrich",
+  address =      "Frankfurt am Main, Germany",
+  pages =        "330",
+  year =         "1982",
+  ISBN =         "3-88682-005-X",
+  ISBN-13 =      "978-3-88682-005-4",
+  LCCN =         "QC16.E5 A25 1982",
+  MRclass =      "01A70",
+  MRnumber =     "MR718489 (85d:01024)",
+  MRreviewer =   "M. Kline",
+  bibdate =      "Wed Nov 23 14:06:24 2005",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/b/born-max.bib;
+                 http://www.math.utah.edu/pub/bibnet/authors/h/heisenberg-werner.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  note =         "With contributions by Hedwig Born, with an
+                 introduction by Bertrand Russell, and with a foreword
+                 by Werner Heisenberg. Reprint of the 1969 edition.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Einstein:1982:HCT,
+  author =       "Albert Einstein",
+  title =        "How {I} created the theory of relativity",
+  journal =      j-PHYS-TODAY,
+  volume =       "35",
+  number =       "8",
+  pages =        "45--47",
+  month =        aug,
+  year =         "1982",
+  CODEN =        "PHTOAD",
+  DOI =          "http://dx.doi.org/10.1063/1.2915203",
+  ISSN =         "0031-9228 (print), 1945-0699 (electronic)",
+  ISSN-L =       "0031-9228",
+  bibdate =      "Wed Sep 05 17:10:34 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Introduction and translation by Yoshimasa A. Ono of a
+                 lecture given by Einstein in Kyoto, Japan on 14
+                 December 1922. It was first published in the Japanese
+                 periodical Kaizo in 1923, and more than a
+                 half-century later, in a partial English translation in
+                 \cite{Ogawa:1979:JEE}. Reprinted in
+                 \cite[243--245]{Weart:1985:HP}.",
+  URL =          "http://www.physicstoday.org/resource/1/phtoad/v35/i8/p45_s1",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Physics Today",
+  journal-URL =  "http://www.physicstoday.org/",
+  remark =       "It has long been uncertain whether Einstein in 1905
+                 knew of the results of the now-famous
+                 {Michelson--Morley} experiment of 1887 that showed the
+                 absence of an aether. In this lecture, Einstein says
+                 that he {\em did\/} know of that work, as well as the
+                 Lorentz monograph of 1895, and the Fizeau experiment of
+                 1851 to measure the relative speeds of light in moving
+                 water. However, Einstein's prior knowledge of the
+                 Michelson--Morley work is disputed in
+                 \cite{Itagaki:1999:EKL}.",
+}
+
+@Book{Einstein:1982:IO,
+  author =       "Albert Einstein",
+  title =        "Ideas and opinions",
+  publisher =    pub-THREE-RIVERS,
+  address =      pub-THREE-RIVERS:adr,
+  pages =        "377",
+  year =         "1982",
+  ISBN =         "0-517-88440-2",
+  ISBN-13 =      "978-0-517-88440-9",
+  LCCN =         "AC35 .E526 1982x",
+  bibdate =      "Wed Mar 8 11:01:08 MST 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 http://www.math.utah.edu/pub/tex/bib/master.bib;
+                 z3950.gbv.de:20011/gvk",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Based on {\em Mein Weltbild}, edited by Cal Seelig,
+                 with new translations and revisions by Sonja
+                 Bargmann.",
+}
+
+@InCollection{Einstein:1982:SGT,
+  author =       "Albert Einstein",
+  title =        "The Special and General Theory of Relativity",
+  crossref =     "College:1982:MU",
+  pages =        "??--??",
+  year =         "1982",
+  bibdate =      "Fri Jul 05 16:04:57 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1982:SR,
+  author =       "Albert Einstein",
+  title =        "Science and religion",
+  crossref =     "College:1982:MU",
+  pages =        "??--??",
+  year =         "1982",
+  bibdate =      "Fri Jul 05 16:04:57 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Errera:1982:STE,
+  author =       "M. Errera and A. Einstein",
+  title =        "Effets {\`a} court terme d'explosions nucl{\'e}aires.
+                 ({French}) [{Short} term effects of nuclear
+                 explosions]",
+  journal =      "Bulletin et m{\'e}moires de l'Acad{\'e}mie royale de
+                 m{\'e}decine de Belgique",
+  volume =       "137",
+  number =       "8--9",
+  pages =        "560--568",
+  month =        "????",
+  year =         "1982",
+  ISSN =         "0377-8231",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Book{Einstein:1983:SR,
+  author =       "Albert Einstein",
+  title =        "Sidelights on {Relativity}",
+  publisher =    pub-DOVER,
+  address =      pub-DOVER:adr,
+  pages =        "56",
+  year =         "1983",
+  ISBN =         "0-486-24511-X (paperback)",
+  ISBN-13 =      "978-0-486-24511-9 (paperback)",
+  LCCN =         "QC173.58 .E5513 1983",
+  bibdate =      "Wed Sep 28 06:10:46 MDT 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  price =        "US\$2.25",
+  URL =          "ftp://uiarchive.cso.uiuc.edu/pub/etext/gutenberg/;
+                 http://www.loc.gov/catdir/description/dover032/83005275.html",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Translation of: {\em {\"A}ther und
+                 Relativit{\"a}ts-Theorie\/} and {\em Geometrie und
+                 Erfahrung}, Reprint. Previously published: New York: E.
+                 P. Dutton, 1923.",
+  subject =      "Relativity (physics)",
+}
+
+@Article{CHP:CHP4760040103,
+  author =       "Albert Einstein",
+  title =        "Letter to a friend of peace",
+  journal =      "M{\"o}bius: A Journal for Continuing Education
+                 Professionals in Health Sciences",
+  volume =       "4",
+  number =       "1",
+  pages =        "5--5",
+  year =         "1984",
+  DOI =          "http://dx.doi.org/10.1002/chp.4760040103",
+  ISSN =         "0894-1912 (print), 1554-558X (electronic)",
+  ISSN-L =       "0894-1912",
+  bibdate =      "Sat Feb 9 08:38:48 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Check: is the author of this letter the subject of
+                 this bibliography?? Is this letter is a reprint of work
+                 prior to his death in 1955??",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1984:BN,
+  author =       "Albert Einstein",
+  title =        "Biographical note",
+  crossref =     "Berger:1984:JCM",
+  pages =        "ix--x",
+  year =         "1984",
+  MRclass =      "01A70",
+  MRnumber =     "MR776073 (87a:01035a)",
+  MRreviewer =   "H. Treder",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1984:EQA,
+  author =       "Albert Einstein and James Clerk Maxwell",
+  title =        "{Einstein}'s quotations about {Maxwell}",
+  crossref =     "Berger:1984:JCM",
+  pages =        "11--14",
+  year =         "1984",
+  MRclass =      "01A70",
+  MRnumber =     "MR776075 (87a:01035c)",
+  MRreviewer =   "H. Treder",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1984:MR,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  volume =       "1921",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  edition =      "Sixth",
+  pages =        "166",
+  year =         "1984",
+  ISBN =         "????",
+  ISBN-13 =      "????",
+  LCCN =         "????",
+  bibdate =      "Wed Nov 23 11:39:22 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "The Stafford Little lectures",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1985:HCT,
+  author =       "Albert Einstein",
+  title =        "How {I} created the theory of relativity",
+  crossref =     "Weart:1985:HP",
+  pages =        "243--245",
+  year =         "1985",
+  bibdate =      "Fri Jan 22 05:37:29 2016",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprint of \cite{Einstein:1982:HCT}.",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einshtein:1985:HTR,
+  author =       "A. E{\u\i}nshte{\u\i}n",
+  booktitle =    "{Einstein} collection, 1980--1981",
+  title =        "How the {Theory of Relativity} came about",
+  publisher =    pub-NAUKA,
+  address =      pub-NAUKA:adr,
+  pages =        "5--9, 334",
+  year =         "1985",
+  MRclass =      "01A60 (83-03)",
+  MRnumber =     "MR845787 (88e:01036)",
+  MRreviewer =   "H. Treder",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "Russian",
+}
+
+@Article{Einshtein:1985:MDS,
+  author =       "A. E{\u\i}nshte{\u\i}n",
+  title =        "A method of determining statistical values of
+                 observations concerning quantities subject to irregular
+                 fluctuations",
+  journal =      j-PROBL-PEREDA-INF,
+  volume =       "21",
+  number =       "4",
+  pages =        "99--100",
+  year =         "1985",
+  CODEN =        "PPDIA5",
+  ISSN =         "0555-2923",
+  MRclass =      "01A60",
+  MRnumber =     "MR820713 (87g:01035b)",
+  MRreviewer =   "H. Treder",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated from the French by B. E. Yavelov",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Akademiya Nauk SSSR. Institut Problem Peredachi
+                 Informatsii Akademii Nauk SSSR. Problemy Peredachi
+                 Informatsii",
+  language =     "Russian",
+}
+
+@InCollection{Einstein:1985:LWP,
+  author =       "Albert Einstein",
+  title =        "Letter to {W. Pauli, 19 September 1938, AE 19-175}",
+  crossref =     "Pauli:2001:WBBa",
+  volume =       "2",
+  pages =        "??--??",
+  year =         "1985",
+  bibdate =      "Sat Oct 28 17:24:54 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1985:STE,
+  author =       "Albert Einstein",
+  title =        "Sobre la teor{\'\i}a especial y la teor{\'\i}a general
+                 de la relatividad: El significado de la relatividad",
+  volume =       "2",
+  publisher =    "Planeta-Agostini",
+  address =      "Barcelona, Spain",
+  pages =        "237",
+  year =         "1985",
+  ISBN =         "84-395-0002-5",
+  ISBN-13 =      "978-84-395-0002-5",
+  LCCN =         "????",
+  bibdate =      "Mon Oct 10 08:15:03 MDT 2011",
+  bibsource =    "fsz3950.oclc.org:210/WorldCat;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "Obras maestras del pensamiento contempor{\'a}neo",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Relatividad (F{\'i}sica); Relatividad, Teor{\'i}a de
+                 la",
+}
+
+@Article{Einstein:1985:WWL,
+  author =       "A. Einstein",
+  title =        "Why War --- a Letter from {Albert Einstein} to
+                 {Sigmund Freud}",
+  journal =      "UNESCO Courier",
+  volume =       "??",
+  number =       "5",
+  pages =        "5--5",
+  month =        "????",
+  year =         "1985",
+  ISSN =         "0041-5278",
+  bibdate =      "Tue Jun 11 13:52:21 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Bose:1986:SQO,
+  author =       "S. N. Bose and A. Einstein and E. Schr{\"o}dinger",
+  title =        "La statistica quantistica e le onde di materia.
+                 ({Italian}) [Quantum statistics and matter waves]",
+  volume =       "3",
+  publisher =    "Bibliopolis",
+  address =      "Naples, Italy",
+  pages =        "99",
+  year =         "1986",
+  ISBN =         "88-7088-128-8",
+  ISBN-13 =      "978-88-7088-128-8",
+  MRclass =      "01A75 (81-03)",
+  MRnumber =     "MR927510 (89b:01075)",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated from the German by Paolo Bernardini",
+  series =       "Saggi di Scienze e Filosofia Naturale [Essays on
+                 Natural Philosophy and Natural Science]",
+  acknowledgement = ack-nhfb,
+  language =     "Italian",
+}
+
+@InCollection{Einshtein:1986:MDSa,
+  author =       "A. E{\u\i}nshte{\u\i}n",
+  booktitle =    "{Einstein} collection, 1982--1983 ({Russian})",
+  title =        "A method for the determination of the statistical
+                 values of observations related to quantities subjected
+                 to irregular fluctuations",
+  publisher =    pub-NAUKA,
+  address =      pub-NAUKA:adr,
+  pages =        "15--16",
+  year =         "1986",
+  MRclass =      "01A60 (62E99)",
+  MRnumber =     "MR896928 (89f:01053)",
+  MRreviewer =   "D. ter Haar",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated from the French by B. E. Yavelov",
+  acknowledgement = ack-nhfb,
+  language =     "Russian",
+}
+
+@InCollection{Einshtein:1986:STR,
+  author =       "A. E{\u\i}nshte{\u\i}n",
+  booktitle =    "{Einstein} collection, 1982--1983 ({Russian})",
+  title =        "The {Special Theory of Relativity}",
+  publisher =    pub-NAUKA,
+  address =      pub-NAUKA:adr,
+  pages =        "7--14",
+  year =         "1986",
+  MRclass =      "01A60 (83-03)",
+  MRnumber =     "MR896927 (88i:01066)",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated from the Japanese by L. Z.
+                 Ponizovski{\u\i}",
+  acknowledgement = ack-nhfb,
+  language =     "Russian",
+}
+
+@InCollection{Einstein:1986:CCG,
+  author =       "Albert Einstein",
+  title =        "Cosmological considerations on the {General Theory of
+                 Relativity}",
+  crossref =     "Bernstein:1986:CCP",
+  pages =        "16--26",
+  year =         "1986",
+  bibdate =      "Mon Jun 04 06:13:07 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation of \cite{Einstein:1917:KBA}.",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1986:CWF,
+  author =       "Albert Einstein",
+  title =        "Comments on the work of {A. Friedmann}",
+  crossref =     "Bernstein:1986:CCP",
+  pages =        "66--67",
+  year =         "1986",
+  bibdate =      "Mon Jun 04 06:15:25 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation of
+                 \cite{Einstein:1922:BAF,Einstein:1923:NAF}",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1986:MDS,
+  author =       "A. Einstein",
+  title =        "Method for the Determination of Statistical Values of
+                 Observations Concerning Sizes Submitted to Irregular
+                 Fluctuations (Reprinted from {{Arch. Sci.
+                 Phys. et Naturf}}, Vol {\bf 37}, Pg 254--2568 1914)",
+  journal =      "Izvestiya Akademii Nauk {SSSR} Fizika Atmosfery i
+                 Okeana",
+  volume =       "22",
+  number =       "1",
+  pages =        "99--100",
+  month =        jan,
+  year =         "1986",
+  ISSN =         "0002-3515",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1987:MDS,
+  author =       "Albert Einstein",
+  title =        "Method for Determining the Statistical Values of
+                 Observations Relating to Quantities Subjected to
+                 Irregular Fluctuations",
+  journal =      j-IEEE-ASSP-MAG,
+  volume =       "4",
+  number =       "4",
+  pages =        "6--11",
+  month =        oct,
+  year =         "1987",
+  DOI =          "http://dx.doi.org/10.1109/MASSP.1987.1165595",
+  ISSN =         "0740-7467 (print), 1558-1284 (electronic)",
+  ISSN-L =       "0740-7467",
+  bibdate =      "Fri Jun 08 06:30:26 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "English translation of \cite{Einstein:1914:MPD}.",
+  acknowledgement = ack-nhfb,
+  fjournal =     "IEEE ASSP magazine",
+  remark =       "Check: PDF file from IEEE Xplore database has only one
+                 page, but its Web data say that the page count is 6.",
+  xxpages =      "6--6",
+}
+
+@Article{Einstein:1987:NMI,
+  author =       "A. Einstein",
+  title =        "{Newton} Mechanics and its Influence on Theoretical
+                 Physics",
+  journal =      "Revista de Occidente",
+  volume =       "??",
+  number =       "68",
+  pages =        "67--76",
+  month =        jan,
+  year =         "1987",
+  ISSN =         "0034-8635",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1988:MR,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  volume =       "1921",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  edition =      "Fifth",
+  pages =        "166",
+  year =         "1988",
+  ISBN =         "0-691-08007-0, 0-691-02352-2 (paperback)",
+  ISBN-13 =      "978-0-691-08007-9, 978-0-691-02352-6 (paperback)",
+  LCCN =         "QC6 .E5 1979; QC173.55",
+  MRclass =      "83-01 (01A75)",
+  MRnumber =     "MR1042572 (90k:83002)",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "The Stafford Little lectures",
+  acknowledgement = ack-nhfb,
+  remark =       "Reprint of the fifth edition (1974); first edition
+                 (1923).",
+  xxpages =      "vi + 169",
+}
+
+@Book{Einstein:1988:SAR,
+  author =       "Albert Einstein",
+  title =        "{{\"U}}ber die spezielle und die allgemeine
+                 {Relativit}{\"a}tstheorie. ({German}) [{On} the
+                 {Special and General Theory of Relativity}]",
+  volume =       "26",
+  publisher =    pub-VIEWEG,
+  address =      pub-VIEWEG:adr,
+  edition =      "Third",
+  pages =        "x + 112",
+  year =         "1988",
+  ISBN =         "3-528-16059-4",
+  ISBN-13 =      "978-3-528-16059-3",
+  MRclass =      "01A75 (83-03)",
+  MRnumber =     "MR985753 (89m:01139)",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "Facetten der Physik [Facets of Physics]",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Book{Einstein:1989:CF,
+  author =       "Albert Einstein and Michel Biezunski and others",
+  title =        "Correspondances fran{\c{c}}aises",
+  volume =       "4",
+  publisher =    "{\'E}ditions du Seuil",
+  address =      "Paris, France",
+  pages =        "345 + 4",
+  year =         "1989",
+  ISBN =         "2-02-010177-7 (Seuil), 2-222-04332-8 (CNRS),
+                 2-02-011390-2 (Collection)",
+  ISBN-13 =      "978-2-02-010177-6 (Seuil), 978-2-222-04332-4 (CNRS),
+                 978-2-02-011390-8 (Collection)",
+  LCCN =         "QC16.E5 A612 B34",
+  bibdate =      "Sun Sep 25 09:51:44 MDT 2011",
+  bibsource =    "atrium.bib.umontreal.ca:210/advance;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translation to French by Emanuelle Aurenche from
+                 German and English.",
+  series =       "Sources du savoir; Oeuvres choisies / Albert
+                 Einstein",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  language =     "French",
+  remark =       "Ouvrage publi{\'e} avec le concours du Centre national
+                 des lettres.",
+  subject =      "Einstein, Albert; Correspondance; Physiciens;
+                 Scientifiques",
+  subject-dates = "1879--1955",
+}
+
+@Book{Einstein:1989:CJV,
+  author =       "Albert Einstein",
+  title =        "Comment je vois le monde. ({French}) [{How} {I} see
+                 the world]",
+  volume =       "183",
+  publisher =    "Flammarion",
+  address =      "Paris, France",
+  pages =        "189",
+  year =         "1989",
+  ISBN =         "2-08-081183-5",
+  ISBN-13 =      "978-2-08-081183-7",
+  LCCN =         "QC71 .E3614 1989",
+  bibdate =      "Fri Aug 21 09:04:23 MDT 2015",
+  bibsource =    "fsz3950.oclc.org:210/WorldCat;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translation from German by R{\'e}gis Hanrion.",
+  series =       "Champs",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  language =     "French",
+  remark =       "Reissued with same iSBN 1990--1998.",
+  subject =      "Science; Philosophy; Social aspects; Physics; Jews;
+                 Peace; Jews.; Peace.; Physics.; Philosophy.; Social
+                 aspects.",
+}
+
+@Book{Einstein:1989:MLY,
+  author =       "Albert Einstein",
+  title =        "Out of my later years",
+  publisher =    "Bonanza Books",
+  address =      "New York, NY, USA",
+  pages =        "282",
+  year =         "1989",
+  ISBN =         "0-517-69417-4",
+  ISBN-13 =      "978-0-517-69417-6",
+  LCCN =         "QC16.E5 A3 1989",
+  bibdate =      "Fri Nov 25 11:28:27 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Revised reprint of 196 edition (Philosophical Library,
+                 New York).",
+  subject =      "Einstein, Albert",
+  subject-dates = "1879--1955",
+}
+
+@Book{Einstein:1989:QMS,
+  author =       "Albert Einstein and Fran{\c{c}}oise Balibar and
+                 Olivier Darrigol and Bruno Jech and others",
+  title =        "Quanta: m{\'e}canique statistique et physique
+                 quantique. ({French}) [{Quanta}: Statistical mechanics
+                 and quantum physics]",
+  volume =       "1",
+  publisher =    "{\'E}ditions du Seuil",
+  address =      "Paris, France",
+  pages =        "270 + 2",
+  year =         "1989",
+  ISBN =         "2-02-010027-4 (Seuil), 2-222-04333-6 (CNRS),
+                 2-02-011390-2 (collection)",
+  ISBN-13 =      "978-2-02-010027-4 (Seuil), 978-2-222-04333-1 (CNRS),
+                 978-2-02-011390-8 (collection)",
+  LCCN =         "QC16.E5 A612 B34",
+  bibdate =      "Sun Sep 25 09:51:44 MDT 2011",
+  bibsource =    "atrium.bib.umontreal.ca:210/advance;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translation by Fran{\c{c}}oise Balibar from German to
+                 French.",
+  series =       "Sources du savoir; Oeuvres choisies / Albert
+                 Einstein",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  language =     "French",
+  remark =       "Ouvrage publi{\'e} avec le concours du Centre national
+                 des lettres.",
+  subject =      "Th{\'e}orie quantique; M{\'e}canique statistique",
+}
+
+@Article{Einstein:1989:TC,
+  author =       "A. Einstein",
+  title =        "Tributes to Contemporaries",
+  journal =      "{Sinn und Form}",
+  volume =       "41",
+  number =       "2",
+  pages =        "232--240",
+  month =        mar # "\slash " # apr,
+  year =         "1989",
+  ISSN =         "0037-5756",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1989:WS,
+  author =       "A. Einstein",
+  title =        "Why Socialism?",
+  journal =      "Monthly Review --- an Independent Socialist Magazine",
+  volume =       "40",
+  number =       "8",
+  pages =        "14--21",
+  month =        jan,
+  year =         "1989",
+  ISSN =         "0027-0520",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1990:IFC,
+  author =       "Albert Einstein",
+  title =        "[inconnu]. ({French}) [{Contributions} to quantum
+                 theory]",
+  journal =      "Annales de la Fondation Louis de Broglie",
+  volume =       "15",
+  number =       "??",
+  pages =        "121--129",
+  month =        "????",
+  year =         "1990",
+  ISSN =         "0182-4295 (print), 2108-6397 (electronic)",
+  ISSN-L =       "0182-4295",
+  bibdate =      "Thu Oct 16 17:44:25 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "TO DO: Find original French title; online references
+                 to this paper omit the title, and the journal does not
+                 appear to have online archives before 1999??",
+  URL =          "http://aflb.ensmp.fr/AFLB-Web/fldb-annales-index.htm",
+  acknowledgement = ack-nhfb,
+  ajournal =     "Ann. Fond. Louis de Broglie",
+  language =     "French",
+}
+
+@Book{Lorentz:1990:RG,
+  author =       "H. A. Lorentz and A. Einstein and H. Minkowski",
+  title =        "{Das Relativit{\"a}tsprinzip}. ({German}) [{The
+                 Principle of Relativity}]",
+  publisher =    pub-TEUBNER,
+  address =      pub-TEUBNER:adr,
+  edition =      "Ninth",
+  pages =        "vi + 159",
+  year =         "1990",
+  ISBN =         "3-519-07306-4",
+  ISBN-13 =      "978-3-519-07306-2",
+  MRclass =      "01A75 (83-01 83-03)",
+  MRnumber =     "MR1211637 (94a:01043)",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Eine Sammlung von Abhandlungen. [A collection of
+                 essays]. With a contribution by H. Weyl, annotations by
+                 A. Sommerfeld and forewords by O. Blumenthal.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Article{Stavis:1990:CBB,
+  author =       "Barrie Stavis and Albert Einstein",
+  title =        "Correspondence between {Barrie Stavis} and {Albert
+                 Einstein}",
+  journal =      "Cardozo Studies in Law and Literature",
+  volume =       "2",
+  number =       "2",
+  pages =        "??--??",
+  month =        "Autumn",
+  year =         "1990",
+  bibdate =      "Fri Nov 25 11:18:35 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "2-%23;
+                 http://links.jstor.org/sici?sici=1043-1500(199023/24)2:2<:CBBSAA>2.0.CO",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1991:AEF,
+  author =       "Albert Einstein",
+  title =        "{Albert Einstein to Franklin D. Roosevelt, August 2,
+                 1939}",
+  crossref =     "Cantelon:1991:AAD",
+  pages =        "9--10",
+  year =         "1991",
+  bibdate =      "Wed Mar 25 12:13:18 2015",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1991:AN,
+  author =       "Albert Einstein",
+  title =        "Autobiographical notes",
+  crossref =     "Ferris:1991:WTP",
+  pages =        "577--589",
+  year =         "1991",
+  bibdate =      "Mon Sep 29 12:29:11 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1991:EMC,
+  author =       "Albert Einstein",
+  title =        "{$ E = m c^2 $}",
+  crossref =     "Ferris:1991:WTP",
+  pages =        "56--59",
+  year =         "1991",
+  bibdate =      "Mon Sep 29 12:29:11 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1991:EPF,
+  author =       "Albert Einstein and Jean-Philippe Mathieu and others",
+  title =        "{{\'E}}crits politiques. ({French} [{Political}
+                 writings])",
+  volume =       "6",
+  publisher =    "{\'E}ditions du Seuil",
+  address =      "Paris, France",
+  pages =        "289",
+  year =         "1991",
+  ISBN =         "2-02-010181-5, 2-222-04646-7",
+  ISBN-13 =      "978-2-02-010181-3, 978-2-222-04646-2",
+  LCCN =         "QC16.E5 A612 B34",
+  bibdate =      "Sun Sep 25 09:51:44 MDT 2011",
+  bibsource =    "atrium.bib.umontreal.ca:210/advance;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translation by Jacques Duvernet and others from German
+                 to French.",
+  series =       "Sources du savoir; Oeuvres choisies / Albert
+                 Einstein",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  language =     "French",
+  remark =       "Oeuvres choisies d'Albert Einstein sous la direction
+                 de Fran{\c{c}}oise Balibar",
+  subject =      "Science politique",
+}
+
+@InCollection{Einstein:1991:LMB,
+  author =       "Albert Einstein",
+  title =        "From Letters to {Max Born}",
+  crossref =     "Ferris:1991:WTP",
+  pages =        "808--809",
+  year =         "1991",
+  bibdate =      "Mon Sep 29 11:35:14 2014",
+  bibsource =    "http://www.math.utah.edu/pub/bibnet/authors/b/born-max.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1991:PNP,
+  author =       "Albert Einstein and Bertrand Russell",
+  title =        "Le pouvoir nu: propos sur la guerre et la paix,
+                 1914--1955. ({French}) [{Raw} power: on war and peace,
+                 1914--1955]",
+  publisher =    "Hermann",
+  address =      "Paris, France",
+  pages =        "222",
+  year =         "1991",
+  ISBN =         "2-7056-6156-4",
+  ISBN-13 =      "978-2-7056-6156-4",
+  LCCN =         "????",
+  bibdate =      "Sun Sep 25 09:51:44 MDT 2011",
+  bibsource =    "atrium.bib.umontreal.ca:210/advance;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "Collection Savoir/Cultures",
+  acknowledgement = ack-nhfb,
+  author-dates = "Albert Einstein (1879--1955), Bertrand Russell
+                 (1872--1970)",
+  language =     "French",
+  remark =       "En partie traduit de Einstein on peace.",
+  subject =      "Paix; Histoire; 20e si{\`e}cle",
+}
+
+@InCollection{Einstein:1991:SR,
+  author =       "Albert Einstein",
+  title =        "Science and religion",
+  crossref =     "Ferris:1991:WTP",
+  pages =        "828--836",
+  year =         "1991",
+  bibdate =      "Mon Sep 29 12:29:11 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1991:TMP,
+  author =       "Albert Einstein",
+  title =        "Tribute to {Max Planck}",
+  crossref =     "Ferris:1991:WTP",
+  pages =        "590--590",
+  year =         "1991",
+  bibdate =      "Mon Sep 29 12:29:11 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1992:WS,
+  author =       "A. Einstein",
+  title =        "Why Socialism?",
+  journal =      "Monthly Review --- an Independent Socialist Magazine",
+  volume =       "44",
+  number =       "1",
+  pages =        "1--8",
+  month =        may,
+  year =         "1992",
+  ISSN =         "0027-0520",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1993:CPAa,
+  author =       "Albert Einstein",
+  title =        "The collected papers of {Albert Einstein}. {Vol}. 3",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "xxxvi + 644",
+  year =         "1993",
+  ISBN =         "0-691-08772-5",
+  ISBN-13 =      "978-0-691-08772-6",
+  MRclass =      "01A75",
+  MRnumber =     "MR1261416 (94m:01042)",
+  MRreviewer =   "H. Treder",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "The Swiss years: writings, 1909--1911, Edited by
+                 Martin J. Klein, Anne J. Kox, J{\"u}rgen Renn and
+                 Robert Schulmann.",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1993:CPAb,
+  author =       "Albert Einstein",
+  title =        "The collected papers of {Albert Einstein}. {Vol}. 5",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "xlxx + 724",
+  year =         "1993",
+  ISBN =         "0-691-03322-6",
+  ISBN-13 =      "978-0-691-03322-8",
+  MRclass =      "01A75 (00A79)",
+  MRnumber =     "MR1301558 (95k:01031a)",
+  MRreviewer =   "H. Treder",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "The Swiss years: correspondence, 1902--1914, Edited by
+                 Martin J. Klein, Anne J. Kox and Robert Schulmann",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1993:F,
+  author =       "Albert Einstein",
+  editor =       "Max Jammer",
+  booktitle =    "Concepts of Space: the history of theories of space in
+                 physics",
+  title =        "Foreword",
+  publisher =    pub-DOVER,
+  address =      pub-DOVER:adr,
+  edition =      "Third",
+  bookpages =    "xvii + 261",
+  pages =        "??--??",
+  year =         "1993",
+  ISBN =         "0-486-27119-6",
+  ISBN-13 =      "978-0-486-27119-4",
+  LCCN =         "QC6 .J3",
+  bibdate =      "Sat Jul 17 14:04:32 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "See also earlier editions
+                 \cite{Einstein:1954:F,Einstein:1969:F}.",
+  acknowledgement = ack-nhfb,
+  Calaprice-number = "288b",
+}
+
+@Book{Einstein:1993:MLY,
+  author =       "Albert Einstein",
+  title =        "Out of my later years: the scientist, philosopher, and
+                 man portrayed through his own words",
+  publisher =    "Wings Books",
+  address =      "New York, NY, USA",
+  pages =        "282",
+  year =         "1993",
+  ISBN =         "0-517-09380-4",
+  ISBN-13 =      "978-0-517-09380-1",
+  LCCN =         "QC16.E5 A3 1993",
+  bibdate =      "Fri Nov 25 11:28:25 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  URL =          "ftp://uiarchive.cso.uiuc.edu/pub/etext/gutenberg/;
+                 http://www.loc.gov/catdir/description/random0414/93024932.html",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Originally published in 1956 (Philosophical Library,
+                 New York).",
+  subject =      "Einstein, Albert; Relativity (physics); Physics;
+                 Philosophy; Physicists; Biography",
+  subject-dates = "1879--1955",
+  tableofcontents = "Relativity \\
+                 Ideas and opinions \\
+                 Out of my later years",
+}
+
+@Article{Einstein:1993:WSR,
+  author =       "A. Einstein",
+  title =        "Why Socialism?",
+  journal =      "Pens{\'e}e",
+  volume =       "??",
+  number =       "294--95",
+  pages =        "113--117",
+  month =        jul # "\slash " # oct,
+  year =         "1993",
+  ISSN =         "0031-4773",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted from Monthly Review, Vol {\bf
+                 1}, May 1949.",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1994:CCM,
+  author =       "Albert Einstein",
+  title =        "Correspondencia con {Mich{\`e}le Besso} (1903--1955).
+                 ({Spanish}) [Correspondence with Mich{\`e}le Besso
+                 (1903--1955)]",
+  volume =       "36",
+  publisher =    "Tusquets Editores S. A.",
+  address =      "Barcelona, Spain",
+  pages =        "476",
+  year =         "1994",
+  ISBN =         "84-7223-771-0",
+  ISBN-13 =      "978-84-7223-771-1",
+  MRclass =      "01A75 (01A70)",
+  MRnumber =     "MR1313030 (95i:01029)",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Edited and with an introduction and notes by Pierre
+                 Speziali. Translated from the French by Manuel
+                 Puigcerver.",
+  series =       "Metatemas",
+  acknowledgement = ack-nhfb,
+  language =     "Spanish",
+}
+
+@Book{Einstein:1994:ECM,
+  author =       "Albert Einstein",
+  title =        "Sur l'{\'e}lectrodynamique des corps en mouvement.
+                 ({French}) [{On} the electrodynamics of moving
+                 bodies]",
+  publisher =    "{\'e}ditions Jacques Gabay",
+  address =      "Sceaux, France",
+  pages =        "ii + 146",
+  year =         "1994",
+  ISBN =         "2-87647-155-8",
+  ISBN-13 =      "978-2-87647-155-9",
+  MRclass =      "01A75 (00A79 78-03 83-03)",
+  MRnumber =     "MR1358606 (97a:01072)",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprint of the 1925 translation, Also including
+                 reprints of the French translations of {\em Ether and
+                 Relativity} (1953), {\em Geometry and experience}
+                 (1953), {\em Four lectures on the Theory of Relativity}
+                 (1925), {\em On the cosmological problem} (1960), {\em
+                 The Unified Field Theory} (1960) and {\em Generalized
+                 gravitation theory} (1950)",
+  series =       "Les Grands Classiques Gauthier-Villars.
+                 [Gauthier-Villars Great Classics]",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Book{Einstein:1994:IO,
+  author =       "Albert Einstein",
+  title =        "Ideas and Opinions",
+  publisher =    "Modern Library",
+  address =      "New York, NY, USA",
+  pages =        "xix + 418",
+  year =         "1994",
+  ISBN =         "0-679-60105-8",
+  ISBN-13 =      "978-0-679-60105-0",
+  LCCN =         "QC71 .E54 1994",
+  bibdate =      "Wed Nov 23 11:44:31 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "With an introduction by Alan Lightman. New
+                 translations and revisions by Sonja Bargmann.",
+  acknowledgement = ack-nhfb,
+  tableofcontents = "Ideas and opinions: About freedom \\
+                 About religion \\
+                 About education \\
+                 About friends \\
+                 On politics, government, and pacifism \\
+                 On the Jewish people \\
+                 On Germany \\
+                 Contributions to science",
+}
+
+@Book{Einstein:1994:MR,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    "Easton Press",
+  address =      "Norwalk, CT, USA",
+  edition =      "Collector's",
+  pages =        "xii + 166",
+  year =         "1994",
+  ISBN =         "????",
+  ISBN-13 =      "????",
+  LCCN =         "QC6",
+  bibdate =      "Wed Nov 23 11:39:22 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "The Stafford Little lectures",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1994:WS,
+  author =       "A. Einstein",
+  title =        "Why Socialism?",
+  journal =      "Monthly Review --- an Independent Socialist Magazine",
+  volume =       "46",
+  number =       "1",
+  pages =        "46--53",
+  month =        may,
+  year =         "1994",
+  ISSN =         "0027-0520",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1995:CPA,
+  author =       "Albert Einstein",
+  title =        "The collected papers of {Albert Einstein}. {Vol}. 4",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "xxii + 715",
+  year =         "1995",
+  ISBN =         "0-691-03705-1",
+  ISBN-13 =      "978-0-691-03705-9",
+  MRclass =      "01A75 (00A79 83-03)",
+  MRnumber =     "MR1354394 (96k:01021)",
+  MRreviewer =   "H. Treder",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "The Swiss years: writings, 1912--1914, Edited by
+                 Martin J. Klein, Anne J. Kox, J{\"u}rgen Renn and
+                 Robert Schulmann",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1995:IO,
+  author =       "Albert Einstein",
+  title =        "Ideas and Opinions",
+  publisher =    pub-CROWN-TRADE-PAPERBACKS,
+  address =      pub-CROWN-TRADE-PAPERBACKS:adr,
+  edition =      "Third",
+  pages =        "377",
+  year =         "1995",
+  ISBN =         "0-517-88440-2",
+  ISBN-13 =      "978-0-517-88440-9",
+  LCCN =         "AC30 .E48 1982",
+  bibdate =      "Wed Nov 23 11:44:31 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Based on {\em Mein Weltbild}, edited by Carl Seelig,
+                 and other sources. New translations and revisions by
+                 Sonja Bargmann.",
+  acknowledgement = ack-nhfb,
+  tableofcontents = "Ideas and opinions \\
+                 On politics, government, and pacifism \\
+                 On the Jewish people \\
+                 On Germany \\
+                 Contributions to science",
+}
+
+@Article{Einstein:1995:LEM,
+  author =       "A. Einstein",
+  title =        "Letter to {Mileva Einstein}, 1901: Wife of {Albert
+                 Einstein}",
+  journal =      "{Du --- die Zeitschrift der Kultur}",
+  volume =       "??",
+  number =       "10",
+  pages =        "14--15",
+  month =        oct,
+  year =         "1995",
+  ISSN =         "0012-6837",
+  bibdate =      "Tue Jun 11 13:52:21 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1995:RSG,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: the {Special} and the {General Theory}",
+  publisher =    pub-CROWN-TRADE-PAPERBACKS,
+  address =      pub-CROWN-TRADE-PAPERBACKS:adr,
+  edition =      "Second",
+  pages =        "xiii + 188",
+  year =         "1995",
+  ISBN =         "0-517-88441-0",
+  ISBN-13 =      "978-0-517-88441-6",
+  LCCN =         "????",
+  bibdate =      "Mon Nov 21 05:53:26 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 library.ox.ac.uk:210/ADVANCE",
+  note =         "Authorized translation by Robert W. Lawson.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  tableofcontents = "Part I. The Special Theory of Relativity \\
+                 1: Physical Meaning of Geometrical Propositions \\
+                 2: The System of Co-ordinates \\
+                 3: Space and Time in Classical Mechanics \\
+                 4: The Galileian System of Co-ordinates \\
+                 5: The Principle of Relativity (in the Restricted
+                 Sense) \\
+                 6: The Theorem of the Addition of Velocities Employed
+                 in Classical Mechanics \\
+                 7: The Apparent Incompatibility of the Law of
+                 Propagation of Light with the Principle of Relativity
+                 \\
+                 8: On the Idea of Time in Physics \\
+                 9: The Relativity of Simultaneity \\
+                 10: On the Relativity of the Conception of Distance \\
+                 11: The Lorentz Transformation \\
+                 12: The Behaviour of Measuring-Rods and Clocks in
+                 Motion \\
+                 13: Theorem of the Addition of the Velocities. The
+                 Experiment of Fizeau \\
+                 14: The Heuristic Value of the Theory of Relativity \\
+                 15: General Results of the Theory \\
+                 16: Experience and the Special Theory of Relativity \\
+                 17: Minkowski's Four-Dimensional Space \\
+                 Part II. The General Theory of Relativity \\
+                 18: Special and General Principle of Relativity \\
+                 19: The Gravitational Field \\
+                 20: The Equality of Inertial and Gravitational Mass as
+                 an Argument for the General Postulate of Relativity \\
+                 21: In What Respects Are the Foundations of Classical
+                 Mechanics and of the Special Theory of Relativity
+                 Unsatisfactory? \\
+                 22: A Few Inferences from the General Principle of
+                 Relativity \\
+                 23: Behaviour of Clocks and Measuring-Rods on a
+                 Rotating Body of Reference \\
+                 24: Euclidean and Non-Euclidean Continuum \\
+                 25: Gaussian Co-ordinates \\
+                 26: The Space--Time Continuum of the Special Theory of
+                 Relativity Considered as a Euclidean Continuum \\
+                 27: The Space--Time Continuum of the General Theory of
+                 Relativity Is Not a Euclidean Continuum \\
+                 28: Exact Formulation of the General Principle of
+                 Relativity \\
+                 29: The Solution of the Problem of Gravitation on the
+                 Basis of the General Principle of Relativity \\
+                 Part III. Considerations on the Universe as a Whole \\
+                 30: Cosmological Difficulties of Newton's Theory \\
+                 31: The Possibility of a ``Finite'' and Yet
+                 ``Unbounded'' Universe \\
+                 32: The Structure of Space According to the General
+                 Theory of Relativity Appendices \\
+                 1: Simple Derivation of the Lorentz Transformation \\
+                 2: Minkowski's Four-Dimensional Space (``World'') \\
+                 3: The Experimental Confirmation of the General Theory
+                 of Relativity (a). Motion of the Perihelion of Mercury
+                 (b). Deflection of Light by a Gravitational Field (c).
+                 Displacement of Spectral Lines towards the Red \\
+                 4: The Structure of Space According to the General
+                 Theory of Relativity \\
+                 5: Relativity and the Problem of Space",
+}
+
+@Article{Einstein:1995:RTS,
+  author =       "A. Einstein",
+  title =        "{RBRVS 2.0}: toward a special theory of resource-based
+                 relativity",
+  journal =      "Connecticut medicine",
+  volume =       "59",
+  number =       "1",
+  pages =        "21--26",
+  month =        jan,
+  year =         "1995",
+  ISSN =         "0010-6178",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  xxnote =       "Check: is this a reprint of Albert Einstein's work?",
+}
+
+@Book{Einstein:1996:BSE,
+  author =       "Albert Einstein and Jerry Mayer and John P. Holms",
+  title =        "Bite-size {Einstein}: Quotations on Just About
+                 Everything From the Greatest Mind of the {Twentieth
+                 Century}",
+  publisher =    pub-ST-MARTINS,
+  address =      pub-ST-MARTINS:adr,
+  pages =        "92",
+  year =         "1996",
+  ISBN =         "0-312-14551-9",
+  ISBN-13 =      "978-0-312-14551-4",
+  LCCN =         "QC16.E5 A25 1996b",
+  bibdate =      "Tue Apr 17 09:44:48 MDT 2007",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  URL =          "http://www.loc.gov/catdir/bios/hol054/96018830.html;
+                 http://www.loc.gov/catdir/description/hol042/96018830.html",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "A Thomas Dunne book.",
+  subject =      "Einstein, Albert; Quotations",
+  subject-dates = "1879--1955",
+}
+
+@Book{Einstein:1996:EMS,
+  author =       "Albert Einstein",
+  title =        "{Einstein}'s 1912 manuscript on the {Special Theory of
+                 Relativity}: a facsimile",
+  publisher =    "{George Braziller, in association with the Jacob E.
+                 Safra Philanthropic Foundation and the Israel Museum}",
+  address =      "New York, NY, USA",
+  pages =        "192",
+  year =         "1996",
+  ISBN =         "0-8076-1417-3, 0-8076-1532-3",
+  ISBN-13 =      "978-0-8076-1417-4, 978-0-8076-1532-4",
+  LCCN =         "QC173.65 .E3613 1996",
+  bibdate =      "Mon Oct 3 16:11:03 MDT 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Special Relativity (physics); Einstein, Albert;
+                 Manuscripts; Facsimiles; Manuscripts, German;
+                 Facsimiles; Physicists; Biography",
+  subject-dates = "1879--1955",
+}
+
+@InCollection{Einstein:1996:MMP,
+  author =       "Albert Einstein",
+  editor =       "Jacques Hadamard",
+  booktitle =    "The mathematician's mind: the psychology of invention
+                 in the mathematical field",
+  title =        "A Testimonial from {Prof. Einstein}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  bookpages =    "xix + 143",
+  year =         "1996",
+  ISBN =         "0-691-02931-8 (paperback)",
+  ISBN-13 =      "978-0-691-02931-3 (paperback)",
+  LCCN =         "QA8.4 .H3 1996",
+  bibdate =      "Sat Jul 17 12:23:01 MDT 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  URL =          "http://www.loc.gov/catdir/description/prin021/96027544.html;
+                 http://www.loc.gov/catdir/toc/prin031/96027544.html",
+  acknowledgement = ack-nhfb,
+  author-dates = "1865--1963",
+  remark =       "Originally published: An essay on the psychology of
+                 invention in the mathematical field. Princeton:
+                 Princeton University Press, 1945
+                 \cite{Einstein:1945:TPE}.",
+  subject =      "Mathematics; Philosophy; Mathematicians; Psychology",
+}
+
+@Book{Einstein:1996:MR,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    "MJF Books",
+  address =      "New York, NY, USA",
+  edition =      "Fifth",
+  pages =        "166",
+  year =         "1996",
+  ISBN =         "1-56731-136-9",
+  ISBN-13 =      "978-1-56731-136-5",
+  LCCN =         "QC6",
+  bibdate =      "Wed Sep 28 06:25:37 MDT 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:1996:PR,
+  author =       "Albert Einstein",
+  title =        "Principles of Research",
+  crossref =     "Schirmacher:1996:GES",
+  pages =        "??--??",
+  year =         "1996",
+  bibdate =      "Thu Aug 09 07:33:53 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:1996:RSG,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: the {Special} and the {General Theory}",
+  publisher =    pub-CROWN,
+  address =      pub-CROWN:adr,
+  edition =      "Second",
+  pages =        "xiii + 188",
+  year =         "1996",
+  ISBN =         "0-517-88441-0",
+  ISBN-13 =      "978-0-517-88441-6",
+  bibdate =      "Mon Nov 21 05:53:26 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 library.ox.ac.uk:210/ADVANCE",
+  note =         "Authorized translation by Robert W. Lawson.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Original published in 1961.",
+  tableofcontents = "The Special Theory of Relativity \\
+                 Physical meaning of geometrical propositions \\
+                 The system of co-ordinates \\
+                 Space and time in classical mechanics \\
+                 The Galileian system of co-ordinates \\
+                 The principle of relativity (in the restricted sense)
+                 \\
+                 The theorem of the addition of velocities employed in
+                 classical mechanics \\
+                 The apparent incompatibility of the law of propagation
+                 of light with the principle of relativity \\
+                 On the idea of time in physics \\
+                 The relativity of simultaneity \\
+                 On the relativity of the conception of distance \\
+                 The Lorentz transformation \\
+                 The behaviour of measuring-rods and clocks in motion
+                 \\
+                 Theorem of the addition of the velocities. The
+                 experiment of Fizeau \\
+                 The heuristic value of the theory of relativity \\
+                 General results of the theory \\
+                 Experience and the special theory of relativity \\
+                 Minkowski's four-dimensional space \\
+                 The General Theory of Relativity \\
+                 Special and general principle of relativity \\
+                 The gravitational field \\
+                 The Equality of inertial and gravitational mass as an
+                 argument for the general postulate of relativity \\
+                 In what respects are the foundations of classical
+                 mechanics and of the special theory of relativity
+                 unsatisfactory? \\
+                 A few inferences from the general principle of
+                 relativity \\
+                 Behaviour of clocks and measuring-rods on a rotating
+                 body of reference \\
+                 Euclidean and non-Euclidean continuum \\
+                 Gaussian co-ordinates \\
+                 The space--time continuum of the special theory of
+                 relativity considered as a Euclidean continuum \\
+                 The space--time continuum of the general theory of
+                 relativity is not a Euclidean continuum \\
+                 Exact formulation of the general principle of
+                 relativity \\
+                 The solution of the problem of gravitation on the basis
+                 of the general principle of relativity \\
+                 Considerations on the Universe as a Whole \\
+                 Cosmological difficulties of Newton's theory \\
+                 The possibility of a ``finite'' and yet ``unbounded''
+                 universe \\
+                 The structure of space according to the general theory
+                 of relativity appendices: simple derivation of the
+                 Lorentz transformation \\
+                 Minkowski's four-dimensional space (``world'') \\
+                 The experimental confirmation of the general theory of
+                 relativity \\
+                 (a) Motion of the perihelion of Mercury \\
+                 (b) Deflection of light by a gravitational field \\
+                 (c) Displacement of spectral lines towards the red \\
+                 The structure of space according to the general theory
+                 of relativity \\
+                 Relativity and the problem of space",
+}
+
+@InCollection{Einstein:1996:WTR,
+  author =       "Albert Einstein",
+  title =        "What Is the Theory of Relativity?",
+  crossref =     "Schirmacher:1996:GES",
+  pages =        "??--??",
+  year =         "1996",
+  bibdate =      "Thu Aug 09 07:33:53 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Misc{Einstein:1997:AEL,
+  author =       "Albert Einstein",
+  title =        "{Albert Einstein}'s Letters to {President Franklin
+                 Delano Roosevelt}",
+  howpublished = "World-Wide Web document",
+  year =         "1997",
+  bibdate =      "Mon Oct 09 07:15:41 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://hypertextbook.com/eworld/einstein.shtml;
+                 http://www.anl.gov/Science_and_Technology/History/Anniversary_Frontiers/aetofdr.html",
+  acknowledgement = ack-nhfb,
+  remark =       "Contains the text of four letters, with links to
+                 online resources about Albert Einstein. The first
+                 letter is dated August 2, 1939, just one month before
+                 World War II began on September 1, 1939.",
+}
+
+@Book{Goldman:1997:EGA,
+  author =       "Robert N. Goldman and Albert Einstein",
+  title =        "{Einstein}'s {God}: {Albert Einstein}'s quest as a
+                 scientist and as a {Jew} to replace a forsaken {God}",
+  publisher =    "Jason Aronson",
+  address =      "Northvale, NJ, USA",
+  pages =        "xviii + 166",
+  year =         "1997",
+  ISBN =         "1-56821-983-0",
+  ISBN-13 =      "978-1-56821-983-7",
+  LCCN =         "QC16.E5 G67 1997",
+  bibdate =      "Mon Oct 9 19:03:22 MDT 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+  subject =      "Einstein, Albert; Religion; God (Judaism); Philosophy
+                 and religion",
+  subject-dates = "1879--1955",
+}
+
+@Book{Einstein:1998:CPA,
+  author =       "Albert Einstein",
+  title =        "The collected papers of {Albert Einstein}. {Vol}. 8,
+                 The {Berlin} years: correspondence, 1914--1918",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "xxii + 714",
+  year =         "1998",
+  ISBN =         "0-691-04841-X",
+  ISBN-13 =      "978-0-691-04841-3",
+  bibdate =      "Tue Oct 11 06:12:15 MDT 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.libris.kb.se:210/libr",
+  note =         "English translation by Ann M. Hentschel in
+                 consultation with Klaus Hentschel.",
+  URL =          "http://press.princeton.edu/titles/6174.html",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "One-volume translation of vol. 8 of ``The collected
+                 papers of Albert Einstein'', the companion to the
+                 two-volume, annotated, original-language documentary
+                 ed.''.",
+  subject =      "Relativitetsteori; Theory of Relativity",
+}
+
+@Article{Einstein:1998:WSR,
+  author =       "A. Einstein",
+  title =        "Why socialism?",
+  journal =      "Monthly Review --- an Independent Socialist Magazine",
+  volume =       "50",
+  number =       "1",
+  pages =        "1--7",
+  month =        "????",
+  year =         "1998",
+  ISSN =         "0027-0520",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprinted from Monthly Review, vol {\bf
+                 1}, 1938.",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:1999:VSR,
+  author =       "Albert Einstein",
+  title =        "{Vorlesungen {\"U}ber Spezielle
+                 Relativit{\"a}tstheorie}. ({German}) [{Lectures} on the
+                 {Theory of Special Relativity}]",
+  journal =      j-NUNCIUS,
+  volume =       "14",
+  number =       "2",
+  pages =        "650--661",
+  month =        "????",
+  year =         "1999",
+  CODEN =        "????",
+  DOI =          "http://dx.doi.org/10.1163/182539199x00102",
+  ISSN =         "0394-7394 (print), 1825-3911 (electronic)",
+  ISSN-L =       "0394-7394",
+  bibdate =      "Thu Jun 13 19:24:58 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 http://www.math.utah.edu/pub/tex/bib/nuncius.bib",
+  URL =          "http://booksandjournals.brillonline.com/content/10.1163/182539199x00102",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Nuncius",
+  language =     "German",
+  pagecount =    "12",
+}
+
+@Article{Einstein:2000:EDE,
+  author =       "Albert Einstein",
+  title =        "Elementary derivation of the equivalence of mass and
+                 energy",
+  journal =      "Bull. Amer. Math. Soc., New Ser.",
+  volume =       "37",
+  number =       "1",
+  pages =        "39--44",
+  year =         "2000",
+  CODEN =        "BAMOAD",
+  ISSN =         "0273-0979",
+  ISSN-L =       "0002-9904",
+  bibdate =      "Sat Oct 28 17:09:26 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Reprint of \cite{Einstein:1935:EDE}",
+  URL =          "http://www.ams.org/bull/2000-37-01/S0273-0979-99-00805-8/S0273-0979-99-00805-8.pdf",
+  ZMnumber =     "Zbl 1010.83500",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:2000:EQE,
+  author =       "Albert Einstein and Alice Calaprice",
+  title =        "The expanded quotable {Einstein}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "xliii + 407",
+  year =         "2000",
+  ISBN =         "0-691-07021-0 (cloth)",
+  ISBN-13 =      "978-0-691-07021-6 (cloth)",
+  LCCN =         "QC16.E5 A25 2000",
+  bibdate =      "Thu Sep 23 21:53:34 MDT 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  URL =          "http://www.loc.gov/catdir/bios/prin051/00026873.html;
+                 http://www.loc.gov/catdir/description/prin022/00026873.html;
+                 http://www.loc.gov/catdir/samples/prin031/00026873.html;
+                 http://www.loc.gov/catdir/toc/prin031/00026873.html",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Einstein, Albert; Quotations",
+  subject-dates = "1879--1955",
+}
+
+@Book{Einstein:2000:RSG,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: the {Special} and the {General Theory}",
+  publisher =    pub-HENRY-HOLT,
+  address =      pub-HENRY-HOLT:adr,
+  edition =      "????",
+  pages =        "xiii + 168",
+  year =         "2000",
+  ISBN =         "1-58734-092-5",
+  ISBN-13 =      "978-1-58734-092-5",
+  LCCN =         "QC173.55",
+  bibdate =      "Mon Nov 21 05:53:26 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 library.ox.ac.uk:210/ADVANCE",
+  note =         "Authorized translation by Robert W. Lawson.",
+  series =       "Routledge classics",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Originally published by Methuen, London, UK, 1954.
+                 Previous edition 1946.",
+}
+
+@Article{Einstein:2000:WS,
+  author =       "A. Einstein",
+  title =        "Why socialism?",
+  journal =      "Monthly Review --- an Independent Socialist Magazine",
+  volume =       "52",
+  number =       "1",
+  pages =        "36--43",
+  month =        may,
+  year =         "2000",
+  ISSN =         "0027-0520",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:2000:WSI,
+  author =       "Albert Einstein",
+  title =        "The world as {I} see it",
+  publisher =    pub-CITADEL-PRESS,
+  address =      pub-CITADEL-PRESS:adr,
+  pages =        "xiii + 112",
+  year =         "2000",
+  ISBN =         "0-8065-0711-X",
+  ISBN-13 =      "978-0-8065-0711-8",
+  LCCN =         "AC35 .E35 2000",
+  bibdate =      "Sat Sep 24 13:47:54 MDT 2011",
+  bibsource =    "aubrey.tamu.edu:7090/voyager;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  price =        "US\$10.95",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Reprint of 1984 edition.",
+  subject =      "Physics; Peace; Science; Philosophy; Social aspects;
+                 Jews; Einstein, Albert",
+  subject-dates = "1879--1955",
+  tableofcontents = "Part I. The world as I see it \\
+                 The meaning of life \\
+                 The world as I see it \\
+                 The liberty of doctrine --- {\`a} propos of the Gumbel
+                 case \\
+                 Good and evil \\
+                 The true value of a human being \\
+                 Society and personality \\
+                 Address at the grave of H. A. Lorentz \\
+                 H. A. Lorentz's work in the cause of international
+                 co-operation \\
+                 In honour of Arnold Berliner's seventieth birthday \\
+                 Popper--Lynkmus \\
+                 Obituary of the surgeon, M. Katzenstein \\
+                 Congratulations to Dr. Solf \\
+                 Of wealth \\
+                 Education and educators \\
+                 To the schoolchildren of Japan \\
+                 Teachers and pupils \\
+                 Paradise lost \\
+                 Religion and science \\
+                 The religiousness of science \\
+                 The plight of science \\
+                 Fascism and science \\
+                 Interviewers \\
+                 Thanks to America \\
+                 The university course at Davos \\
+                 Congratulations to a critic \\
+                 Greeting to G. Bernard Shaw \\
+                 Some notes on my American impressions \\
+                 Reply to the women of America \\
+                 Part II. Politics and pacifism \\
+                 Peace \\
+                 The pacifist problem \\
+                 Address to the students' disarmament meeting \\
+                 To Sigmund Freud \\
+                 Compulsory service \\
+                 Germany and France \\
+                 Arbitration \\
+                 The international of science \\
+                 The Institute for Intellectual Co-operation \\
+                 A farewell \\
+                 The question of disarmament \\
+                 The Disarmament Conference of 1932 \\
+                 America and the Disarmament Conference \\
+                 Active pacifism \\
+                 Letter to a friend of peace \\
+                 Another ditto \\
+                 A third ditto \\
+                 Women and war \\
+                 Thoughts on the world economic crisis \\
+                 Culture and prosperity \\
+                 Production and purchasing power \\
+                 Production and work \\
+                 Minorities \\
+                 Observations on the present situation in Europe \\
+                 The heirs of the ages \\
+                 Part III. Germany 1933 \\
+                 Manifesto \\
+                 Correspondence with the Prussian Academy of Sciences
+                 \\
+                 A reply \\
+                 Part IV. The Jews \\
+                 Jewish ideals \\
+                 Is there a Jewish point of view? \\
+                 Jewish youth --- an answer to a questionnaire \\
+                 Addresses on reconstruction in Palestine \\
+                 The Jewish community \\
+                 Working Palestine \\
+                 Jewish recovery \\
+                 Anti-Semitism and academic youth \\
+                 A letter to professor Dr. Hellpach, Minister of State
+                 \\
+                 Letter to an Arab \\
+                 Christianity and Judaism",
+}
+
+@InCollection{Einstein:2001:F,
+  author =       "Albert Einstein",
+  title =        "Foreword",
+  crossref =     "Drake:2001:GGD",
+  pages =        "xxiii--xxx",
+  year =         "2001",
+  bibdate =      "Wed Oct 22 14:47:53 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:2001:RSG,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: the {Special} and the {General Theory}",
+  publisher =    pub-ROUTLEDGE,
+  address =      pub-ROUTLEDGE:adr,
+  edition =      "Fifteenth",
+  pages =        "x + 166",
+  year =         "2001",
+  ISBN =         "0-415-25538-4 (hardcover), 0-415-25384-5 (paperback)",
+  ISBN-13 =      "978-0-415-25538-7 (hardcover), 978-0-415-25384-0
+                 (paperback)",
+  LCCN =         "QC173.55",
+  bibdate =      "Mon Nov 21 05:53:26 MST 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 library.ox.ac.uk:210/ADVANCE",
+  note =         "Authorized translation by Robert W. Lawson.",
+  series =       "Routledge classics",
+  URL =          "http://www.bartleby.com/173/",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Originally published by Methuen, London, UK, 1954.
+                 Previous edition 1946. Full text available online at
+                 the URL.",
+  tableofcontents = "Part I: The Special Theory of Relativity \\
+                 1: Physical Meaning of Geometrical Propositions \\
+                 2: The System of Co-ordinates \\
+                 3: Space and Time in Classical Mechanics \\
+                 4: The Galileian System of Co-ordinates \\
+                 5: The Principle of Relativity (in the Restricted
+                 Sense) \\
+                 6: The Theorem of the Addition of Velocities Employed
+                 in Classical Mechanics \\
+                 7: The Apparent Incompatibility of the Law of
+                 Propagation of Light with the Principle of Relativity
+                 \\
+                 8: On the Idea of Time in Physics \\
+                 9: The Relativity of Simultaneity \\
+                 10: On the Relativity of the Conception of Distance \\
+                 11: The Lorentz Transformation \\
+                 12: The Behaviour of Measuring-Rods and Clocks in
+                 Motion \\
+                 13: Theorem of the Addition of Velocities. The
+                 Experiment of Fizeau \\
+                 14: The Heuristic Value of the Theory of Relativity \\
+                 15: General Results of the Theory \\
+                 16: Experience and the Special Theory of Relativity \\
+                 17: Minkowski's Four-dimensional Space \\
+                 Part II: The General Theory of Relativity \\
+                 18: Special and General Principle of Relativity \\
+                 19: The Gravitational Field \\
+                 20: The Equality of Inertial and Gravitational Mass as
+                 an Argument for the General Postulate of Relativity \\
+                 21: In what Respects are the Foundations of Classical
+                 Mechanics and of the Special Theory of Relativity
+                 Unsatisfactory? \\
+                 22: A Few Inferences from the General Principle of
+                 Relativity \\
+                 23: Behaviour of Clocks and Measuring-Rods on a
+                 Rotating Body of Reference \\
+                 24: Euclidean and non-Euclidean Continuum \\
+                 25: Gaussian Co-ordinates \\
+                 26: The Space--Time Continuum of the Special Theory of
+                 Relativity Considered as a Euclidean Continuum \\
+                 27: The Space--Time Continuum of the General Theory of
+                 Relativity is not a Euclidean Continuum \\
+                 28: Exact Formulation of the General Principle of
+                 Relativity \\
+                 29: The Solution of the Problem of Gravitation on the
+                 Basis of the General Principle of Relativity \\
+                 Part III: Considerations on the Universe as a Whole \\
+                 30: Cosmological Difficulties of Newton's Theory \\
+                 31: The Possibility to a ``Finite'' and yet
+                 ``Unbounded'' Universe \\
+                 32: The Structure of Space according to the General
+                 Theory of Relativity. Appendix 1: Simple Derivation of
+                 the Lorentz Transformation [Supplementary to Section
+                 11] \\
+                 Appendix 2: Minkowski's Four-dimensional Space
+                 (``World'') [Supplementary to Section 17] \\
+                 Appendix 3: The Experimental Confirmation of the
+                 General Theory of Relativity \\
+                 Appendix 4: The Structure of Space according to the
+                 General Theory of Relativity [Supplementary to Section
+                 32] \\
+                 Appendix 5: Relativity and the Problem of Space",
+}
+
+@InCollection{Einstein:2001:ST,
+  author =       "Albert Einstein",
+  title =        "Space--Time",
+  crossref =     "Hoiberg:2001:YNL",
+  pages =        "290--296",
+  year =         "2001",
+  bibdate =      "Tue Apr 07 08:30:59 2015",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:2002:DPE,
+  author =       "Albert Einstein and Alice Calaprice and Robert
+                 Schulmann",
+  title =        "Dear {Professor Einstein}: {Albert Einstein}'s letters
+                 to and from children",
+  publisher =    pub-PROMETHEUS-BOOKS,
+  address =      pub-PROMETHEUS-BOOKS:adr,
+  pages =        "232",
+  year =         "2002",
+  ISBN =         "1-59102-015-8",
+  ISBN-13 =      "978-1-59102-015-8",
+  LCCN =         "QC16.E5 A4 2002",
+  bibdate =      "Fri Sep 3 09:01:45 MDT 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.bibsys.no:2100/BIBSYS",
+  URL =          "http://www.loc.gov/catdir/toc/fy035/2002073570.html",
+  acknowledgement = ack-nhfb,
+  subject =      "Einstein, Albert; children; physicists",
+  tableofcontents = "``I Am Merely Curious'': A Short Biography 33 \\
+                 Einstein's Education / Robert Schulmann 71 \\
+                 An Einstein Picture Gallery 83 \\
+                 The Letters 111",
+}
+
+@Article{Einstein:2002:WS,
+  author =       "A. Einstein",
+  title =        "Why socialism?",
+  journal =      "Monthly Review --- an Independent Socialist Magazine",
+  volume =       "54",
+  number =       "1",
+  pages =        "56--62",
+  month =        may,
+  year =         "2002",
+  ISSN =         "0027-0520",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einshtein:2003:BFR,
+  author =       "Al{\cprime}bert {{\`E}}{\u\i}nshte{\u\i}n",
+  title =        "Bez formul. ({Russian}) [{Without} formula]",
+  publisher =    "Mysl\cprime",
+  address =      "Moscow, Russia",
+  pages =        "224",
+  year =         "2003",
+  ISBN =         "5-244-00981-8",
+  ISBN-13 =      "978-5-244-00981-1",
+  MRclass =      "01A70 (00A79)",
+  MRnumber =     "MR2086687 (2005g:01027)",
+  bibdate =      "Wed Nov 23 14:02:29 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Edited by K. A. Kedrov",
+  acknowledgement = ack-nhfb,
+  language =     "Russian",
+}
+
+@Book{Einstein:2003:EMS,
+  author =       "Albert Einstein and Martin J. Klein",
+  title =        "{Einstein}'s 1912 Manuscript on the {Special Theory of
+                 Relativity}",
+  publisher =    "George Braziller, in association with the Edmond J.
+                 Safra Philanthropic Foundation",
+  address =      "New York, NY, USA",
+  edition =      "Revised",
+  pages =        "174",
+  year =         "2003",
+  ISBN =         "0-8076-1532-3",
+  ISBN-13 =      "978-0-8076-1532-4",
+  LCCN =         "QC173.65 .E3613 2003",
+  bibdate =      "Tue Feb 7 18:27:28 MST 2006",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 melvyl.cdlib.org:210/CDL90",
+  note =         "English and German texts appear on facing pages, with
+                 the German handwritten.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Einstein, Albert; Manuscripts; Facsimiles; Special
+                 Relativity (physics); Manuscripts, German; Physicists;
+                 Biography",
+  subject-dates = "1879--1955",
+  tableofcontents = "Albert Einstein: Scientist, Humanist, Zionist /
+                 Hanoch Gutfreund / 7 \\
+                 In Einstein's Own Words / 11 \\
+                 Chronology of the Life of Albert Einstein / 13 \\
+                 Provenance and Description of Einstein's 1912
+                 Manuscript on the Special Theory of Relativity / 15 \\
+                 Einstein's 1912 Manuscript on the Special Theory of
+                 Relativity / 23",
+}
+
+@Book{Einstein:2003:MR,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  publisher =    pub-ROUTLEDGE,
+  address =      pub-ROUTLEDGE:adr,
+  edition =      "Sixth",
+  pages =        "177",
+  year =         "2003",
+  ISBN =         "0-415-28588-7, 0-203-44953-3 (e-book)",
+  ISBN-13 =      "978-0-415-28588-9, 978-0-203-44953-0 (e-book)",
+  LCCN =         "QC173.55",
+  bibdate =      "Wed Nov 23 11:39:22 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  remark =       "Translated by Edwin Plimpton Adams, with Appendix I
+                 translated by Ernst G. Straus and the Appendix II by
+                 Sonja Bargmann.",
+  tableofcontents = "Space and time in pre-relativity physics \\
+                 The theory of special relativity \\
+                 The general theory of relativity \\
+                 The general theory of relativity (continued) \\
+                 Appendix I. On the 'cosmologic problem' \\
+                 Appendix II. Relativistic theory of the non-symmetric
+                 field",
+}
+
+@Article{Einstein:2003:PR,
+  author =       "Albert Einstein",
+  title =        "Physics \& Reality",
+  journal =      j-DAEDALUS,
+  volume =       "132",
+  number =       "4",
+  pages =        "22--25",
+  month =        "Fall",
+  year =         "2003",
+  CODEN =        "DAEDAU",
+  DOI =          "http://dx.doi.org/10.1162/001152603771338742;
+                 http://dx.doi.org/10.2307/20027877",
+  ISSN =         "0011-5266 (print), 1548-6192 (electronic)",
+  ISSN-L =       "0011-5266",
+  bibdate =      "Thu Mar 19 21:40:18 MDT 2015",
+  bibsource =    "http://www.jstor.org/stable/i20027874;
+                 http://www.math.utah.edu/pub/tex/bib/daedalus.bib;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://www.jstor.org/stable/20027877",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Daedalus",
+  journal-URL =  "http://www.jstor.org/journals/00115266.html;
+                 http://www.mitpressjournals.org/loi/daed",
+}
+
+@Article{Schroeder:2003:EDP,
+  author =       "Hans G. Schroeder and Albert Einstein and Hans
+                 Mushham",
+  title =        "Experimental determination of the pore size of
+                 filters. 1923",
+  journal =      "PDA journal of pharmaceutical science and technology",
+  volume =       "57",
+  number =       "5",
+  pages =        "331--332",
+  month =        sep # "\slash " # oct,
+  year =         "2003",
+  ISSN =         "1079-7440",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "PDA journal of pharmaceutical science and technology /
+                 PDA",
+  xxnote =       "Check: is this a reprint of Albert Einstein's work?",
+}
+
+@Book{Einstein:2004:CPAa,
+  author =       "Albert Einstein and Diana {Kormos Buchwald} and Robert
+                 Schulmann and J{\'o}zsef Illy' Daniel J. Kennefick and
+                 Tilman Sauer",
+  title =        "The collected papers of {Albert Einstein}. {Vol}. 9,
+                 The {Berlin} years: correspondence, {January
+                 1919--April 1920}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "lxxiii + 697 + 8",
+  year =         "2004",
+  ISBN =         "0-691-12088-9",
+  ISBN-13 =      "978-0-691-12088-1",
+  LCCN =         "QC 16 .E5A214 1987",
+  bibdate =      "Tue Oct 11 06:12:15 MDT 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.libris.kb.se:210/libr",
+  URL =          "http://einsteinpapers.press.princeton.edu/vol9-doc;
+                 http://einsteinpapers.press.princeton.edu/vol9-trans;
+                 http://press.princeton.edu/titles/7910.html;
+                 http://press.princeton.edu/titles/7911.html",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Einstein Albert 1879--1955; Relativitetsteori; Fysik;
+                 Physics; Theory of Relativity; Biografi {\"o}ver
+                 fysiker; Biography of physicists; Gravitation",
+}
+
+@Book{Einstein:2004:CPAb,
+  author =       "Albert Einstein and John Stachel",
+  title =        "The collected papers of {Albert Einstein}. {Vol}. 9,
+                 The {Berlin} years: correspondence, {January
+                 1919--April 1920}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "xxi + 358",
+  year =         "2004",
+  ISBN =         "0-691-12124-9",
+  ISBN-13 =      "978-0-691-12124-6",
+  bibdate =      "Tue Oct 11 06:12:15 MDT 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.libris.kb.se:210/libr",
+  URL =          "http://press.princeton.edu/titles/7911.html",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Fysik; Physics; Relativitetsteori; Theory of
+                 Relativity",
+  xxnote =       "Check editors: one catalog has Diana Kormos
+                 Buchwald.",
+}
+
+@Article{Einstein:2004:WS,
+  author =       "A. Einstein",
+  title =        "Why socialism?",
+  journal =      "Monthly Review --- an Independent Socialist Magazine",
+  volume =       "56",
+  number =       "1",
+  pages =        "44--50",
+  month =        may,
+  year =         "2004",
+  ISSN =         "0027-0520",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Eger:2005:EVC,
+  author =       "Joseph Eger and Albert Einstein",
+  title =        "{Einstein}'s violin: a conductor's notes on music,
+                 physics, and social change",
+  publisher =    "Jeremy P. Tarcher\slash Penguin",
+  address =      "New York, NY, USA",
+  pages =        "xiv + 417",
+  year =         "2005",
+  ISBN =         "1-58542-388-2",
+  ISBN-13 =      "978-1-58542-388-0",
+  LCCN =         "ML3800 .E3 2005",
+  bibdate =      "Thu Jan 25 18:50:57 MST 2007",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  abstract =     "In Einstein's Violin, Eger distills more
+                 than half a century of personal experience and what it
+                 has taught him about how music is uncannily similar in
+                 its design to the concepts of `string theory' that have
+                 become overwhelmingly popular in today's theoretical
+                 physics. Eger deals with how music relates not only to
+                 the physical world, but to the social one as well: He
+                 was among the first classical performers to see music
+                 as a force for change, leading him to cross battle
+                 lines in the Middle East, to perform fusion concerts
+                 with musicians such as John Lennon and Yoko Ono, and to
+                 become a voice for social advocacy from the hearing
+                 rooms of the House Un-American Activities Committee to
+                 the stage of Harlem's Apollo Theater.\par
+
+                 Eger's life is a social and artistic tour through music
+                 and science of the twentieth century. In
+                 Einstein's Violin, readers encounter
+                 portraits of figures including Leonard Bernstein, David
+                 Bohm, Albert Einstein, Queen Noor al Hussein, and
+                 Eleanor Roosevelt. Eger also probes the origins of
+                 ancient music in the hands of the Hebrews. Egyptians,
+                 Hindus, ancient Chinese, and the schools of Pythagoras
+                 to plumb the sources of this socially and physically
+                 unifying language of the universe.",
+  acknowledgement = ack-nhfb,
+  subject =      "Music; Philosophy and aesthetics",
+  tableofcontents = "1: How I came to write this book \\
+                 2: Guns in my face: music at my back \\
+                 3: How it all began: back to 1951 \\
+                 4: Fun in music and physics \\
+                 5: What it's like to be a musician \\
+                 6: What is music? \\
+                 7: Songs of praise \\
+                 8: Music as context \\
+                 9: Music's dagger \\
+                 10: Personal wars \\
+                 11: Conductors, consistency, and change \\
+                 12: The audience revolution \\
+                 13: Beethoven, my hero \\
+                 14: Beethoven's music \\
+                 15: Fantastique: Hector Berlioz (1803--1869) \\
+                 16: Einstein the person \\
+                 17: Music and science \\
+                 18: The quantum revolution \\
+                 19: The science of music: the music of science \\
+                 20: Superstring theory \\
+                 21: Race toward the goal \\
+                 22: Superstrings: my neighbor's territory",
+}
+
+@Article{Einstein:2005:AEMa,
+  author =       "A. Einstein",
+  title =        "{Albert Einstein} to {Moritz Schlick}",
+  journal =      j-PHYS-TODAY,
+  volume =       "58",
+  number =       "12",
+  pages =        "17--17",
+  month =        dec,
+  year =         "2005",
+  CODEN =        "PHTOAD",
+  DOI =          "http://dx.doi.org/10.1063/1.2169428",
+  ISSN =         "0031-9228",
+  ISSN-L =       "0031-9228",
+  bibdate =      "Tue Jun 11 13:52:21 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Physics Today",
+  journal-URL =  "http://www.physicstoday.org/",
+}
+
+@Book{Einstein:2005:AEMb,
+  author =       "Albert Einstein",
+  title =        "{Albert Einstein}: Out of My Later Years Through His
+                 Own Word",
+  publisher =    "Castle Books",
+  address =      "Edison, NJ, USA",
+  pages =        "282",
+  year =         "2005",
+  ISBN =         "0-7858-2045-0",
+  ISBN-13 =      "978-0-7858-2045-1",
+  LCCN =         "QC16.E5 A3 2005",
+  bibdate =      "Mon Oct 9 19:08:31 MDT 2006",
+  bibsource =    "clio-db.cc.columbia.edu:7090/Voyager;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Previously published: New York: Philosophical Library,
+                 1956. Convictions and beliefs -- Science -- Public
+                 affairs -- Science and life -- Personalities -- My
+                 people.",
+  subject =      "Einstein, Albert",
+  subject-dates = "1879--1955",
+  tableofcontents = "Convictions and beliefs \\
+                 Science \\
+                 Public affairs \\
+                 Science and life \\
+                 Personalities \\
+                 My people",
+}
+
+@Article{Einstein:2005:AEP,
+  author =       "A. Einstein",
+  title =        "{Albert} {Einstein} to {Paul Ehrenfest}",
+  journal =      j-PHYS-TODAY,
+  volume =       "58",
+  number =       "4",
+  pages =        "88--88",
+  month =        apr,
+  year =         "2005",
+  CODEN =        "PHTOAD",
+  DOI =          "http://dx.doi.org/10.1063/1.1955505",
+  ISSN =         "0031-9228",
+  ISSN-L =       "0031-9228",
+  bibdate =      "Tue Jun 11 13:52:21 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Physics Today",
+  journal-URL =  "http://www.physicstoday.org/",
+}
+
+@Book{Einstein:2005:LMS,
+  author =       "Albert Einstein",
+  title =        "Lettres {\'a} {Maurice Solovine}: reproduites en
+                 facsimil{\'e} et traduites en fran{\c{c}}ais",
+  publisher =    "J. Gabay",
+  address =      "Paris, France",
+  pages =        "xiii + 139",
+  year =         "2005",
+  ISBN =         "2-87647-275-9 (paperback)",
+  ISBN-13 =      "978-2-87647-275-4 (paperback)",
+  LCCN =         "????",
+  bibdate =      "Sat Sep 24 13:40:52 MDT 2011",
+  bibsource =    "carmin.sudoc.abes.fr:210/ABES-Z39-PUBLIC;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:2005:MRa,
+  author =       "Albert Einstein",
+  title =        "The Meaning of {Relativity}",
+  volume =       "1921",
+  publisher =    pub-ROUTLEDGE,
+  address =      pub-ROUTLEDGE:adr,
+  pages =        "177",
+  year =         "2005",
+  ISBN =         "0-203-44953-3",
+  ISBN-13 =      "978-0-203-44953-0",
+  LCCN =         "QC173.55",
+  bibdate =      "Wed Nov 23 11:39:22 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "The Stafford Little lectures",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:2005:MRb,
+  author =       "Albert Einstein and Brian Greene",
+  title =        "The Meaning of {Relativity}",
+  volume =       "1921",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  edition =      "Expanded {Princeton} Science Library",
+  pages =        "xxiv + 166",
+  year =         "2005",
+  ISBN =         "0-691-12027-7",
+  ISBN-13 =      "978-0-691-12027-0",
+  LCCN =         "QC6",
+  bibdate =      "Wed Nov 23 11:39:22 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 http://www.math.utah.edu/pub/tex/bib/physperspect.bib",
+  series =       "The Stafford Little lectures",
+  URL =          "http://press.princeton.edu/titles/484.html",
+  acknowledgement = ack-nhfb,
+  remark =       "With a new introduction by Brian Greene.",
+  tableofcontents = "Introduction by Brian Greene vii \\
+                 A Note on the Fifth Edition xxv \\
+                 Space and Time in Pre-Relativity Physics 1 \\
+                 The Theory of Special Relativity 24 \\
+                 The General Theory of Relativity 55 \\
+                 The General Theory of Relativity (continued) 79 \\
+                 Appendix for the Second Edition 109 \\
+                 Appendix II. Relativistic Theory of the Non-Symmetric
+                 Field 133 \\
+                 Index 167",
+}
+
+@Book{Einstein:2005:MW,
+  author =       "Albert Einstein and Carl Seelig",
+  title =        "{Mein Weltbild}. ({German}) [{My} World View]",
+  volume =       "36728",
+  publisher =    "Ullstein",
+  address =      "Berlin, Germany",
+  pages =        "231",
+  year =         "2005",
+  ISBN =         "3-548-36728-3",
+  ISBN-13 =      "978-3-548-36728-6",
+  LCCN =         "????",
+  bibdate =      "Thu Jul 18 06:22:28 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.gbv.de:20011/gvk",
+  series =       "Ullstein",
+  URL =          "http://www.gbv.de/dms/hebis-darmstadt/toc/127386025.pdf",
+  abstract =     "Er war --- das wei{\ss} jeder -- ein absolut genialer
+                 Wissenschaftler, aber er hatte viel mehr als nur Physik
+                 im Kopf: Albert Einstein (1879--1955), der
+                 weltber{\"u}hmte Physiker, der die
+                 Relativit{\"a}tstheorie begr{\"u}ndet und damit die
+                 Welt der Physik grundlegend ver{\"a}ndert hat, war ein
+                 interessanter, vielseitig interessierter und
+                 eigensinniger Mensch, der die ihn umgebende Welt
+                 analysierte und aus dem Beobachteten scharfsinnig seine
+                 Schl{\"u}sse zog. In diesem Band, der 1934 zum 1. Mal
+                 erschien, hier aber auch Texte aus sp{\"a}terer Zeit
+                 enth{\"a}lt, sind {\"A}u{\ss}erungen und Bekenntnisse
+                 von ihm in Bezug auf seine Weltanschauung gesammelt:
+                 aus Briefen, Reden, Essays usw., zu politischen,
+                 religi{\"o}sen, zeitgeschichtlichen und nat{\"u}rlich
+                 wissenschaftlichen Themen. Da der ``Meister'' hier
+                 selbst geschrieben (respektive gesprochen) und sich
+                 aufs eing{\"a}ngige und ansprechende Formulieren sehr
+                 gut verstanden hat, ist dies eine spannende
+                 Lekt{\"u}re, die mehr vom Menschen Einstein mit all
+                 seinen St{\"a}rken und Schw{\"a}chen aufzeigt als so
+                 manche Biografie. Eine informative Erg{\"a}nzung sind
+                 die Anmerkungen des Herausgebers. {\"A}u{\ss}erst stark
+                 empfohlen.",
+  abstract-en =  "He was, as everyone knows, an absolutely brilliant
+                 Scientist, but he had a lot more than just physics in
+                 mind: Albert Einstein (1879--1955), the world-famous
+                 physicist who founded the Theory of Relativity that
+                 fundamentally changed the world of physics, was a
+                 stubborn man with an broad range of interests about the
+                 world surrounding him, which he perceptively analyzed
+                 and drew conclusions. This volume appeared first in
+                 1934, but contains texts from later periods with
+                 statements and confessions from him relating to his
+                 world, from letters, speeches, essays, etc., on
+                 political, religious, contemporary and natural-science
+                 topics. As the ``master'' has written (or spoken) the
+                 catchy and appealing formulation and has understood it
+                 well, this is a fascinating read, the more the person
+                 Einstein shows his strengths and weaknesses, compared
+                 to some biography. An informative supplement from the
+                 Editor's notes. Extremely strongly recommended.",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+  tableofcontents = "I: Wie ich die Welt sehe / 9 \\
+                 Wie ich die Welt sehe / 9 \\
+                 Vom Sinn des Lebens / 12 \\
+                 Der wahre Wert eines Menschen / 13 \\
+                 Vom Reichtum / 13 \\
+                 Gemeinschaft und Pers{\"o}nlichkeit / 13 \\
+                 Der Staat und das individuelle Gewissen / 16 \\
+                 Gut und B{\"o}se / 17 \\
+                 Religion und Wissenschaft / 17 \\
+                 Die Religiosit{\"a}t der Forschung / 21 \\
+                 \\
+                 Verlorenes Paradies / 22 \\
+                 Die Notwendigkeit der ethischen Kultur / 22 \\
+                 Faschismus und Wissenschaft / 24 \\
+                 Von der Freiheit der Lehre / 25 \\
+                 Neuzeitliche Inquisitionsmethoden / 26 \\
+                 Erziehung zu selbst{\"a}ndigem Denken / 27 \\
+                 Erziehung und Erzieher / 28 \\
+                 An japanische Schulkinder / 28 \\
+                 \\
+                 Lehrer und Sch{\"u}ler / 29 \\
+                 Die Davoser Hochschulkurse / 30 \\
+                 Ansprache am Grabe von H. A. Lorentz / 31 \\
+                 H. A. Lorentz' T{\"a}tigkeit im Dienst der
+                 Zusammenarbeit / 32 \\
+                 H.A. Lorentz als Sch{\"o}pfer und als
+                 Pers{\"o}nlichkeit / 34 \\
+                 Josef Popper-Lynkeus / 37 \\
+                 Zum 70. Geburtstag von Arnold Berliner / 38 \\
+                 Gru{\ss} an George Bernard Shaw / 39 \\
+                 Bertrand Russell und das philosophische Denken / 40 \\
+                 Die Interviewer / 46 \\
+                 Gl{\"u}ckwunsch an einen Kritiker / 47 \\
+                 Meine ersten Eindr{\"u}cke in Nordamerika / 47 \\
+                 Antwort an amerikanische Frauen / 51 \\
+                 II: Politik und Pazifismus / 53 \\
+                 Friede / 53 \\
+                 Zur Abschaffung der Kriegsgefahr / 53 \\
+                 Das pazifistische Problem / 54 \\
+                 Ansprache vor der Abr{\"u}stungsversammlung der
+                 Studenten / 55 \\
+                 Von der Dienstpflicht / 57 \\
+                 An Sigmund Freud / 58 \\
+                 Die Frauen und der Krieg / 60 \\
+                 Drei Briefe an Friedensfreunde / 60 \\
+                 Aktiver Pazifis- mus / 62 \\
+                 Ein Abschied / 63 \\
+                 Zur Frage der Abr{\"u}stung / 64 \\
+                 Zur Abr{\"u}stungskonferenz von 1932 / 65 \\
+                 Amerika und die Abr{\"u}stungskonferenz von 1932 / 71 \\
+                 Vom Schiedsgericht / 73 \\
+                 Die Internationale der Wissenschaft / 74 \\
+                 Von den Minderheiten / 75 \\
+                 Deutschland und Frankreich / 75 \\
+                 Das Institut f{\"u}r geistige Zusammenarbeit / 76 \\
+                 Kultur und Wohlstand / 78 \\
+                 Krankheitssymptome des kulturellen Lebens / 79 \\
+                 Gedanken {\"u}ber die {\"o}konomische Weltkrise / 80 \\
+                 Produktion und Kaufkraft / 84 \\
+                 Produktion und Arbeit / 85 \\
+                 Bemerkungen zur gegenw{\"a}rtigen europ{\"a}ischen
+                 Situation / 86 \\
+                 Vom friedlichen Zusammenleben der Nationen / 87 \\
+                 Zur Sicherung des Menschengeschlechtes / 89 \\
+                 Wir Erben / 90 \\
+                 III: Im Kampf gegen den Nationalsozialismus / 92 \\
+                 Bekenntnis / 92 \\
+                 Briefwechsel mit der Preu{\ss}ischen Akademie der
+                 Wissenschaften / 92 \\
+                 Briefwechsel mit der Bayerischen Akademie der
+                 Wissenschaften / 97 \\
+                 Antwort auf eine Einladung / 98 \\
+                 IV: J{\"u}dische Probleme / 100 \\
+                 J{\"u}dische Ideale / 100 \\
+                 Gibt es eine j{\"u}dische Weltanschauung? / 100 \\
+                 Christentum und Judentum / 102 \\
+                 J{\"u}dische Gemeinschaft / 102 \\
+                 Antisemitismus und akademische Jugend / 105 \\
+                 Ansprachen {\"u}ber das pal{\"a}stinensische Aufbauwerk
+                 / 106 \\
+                 Arbeitendes Pal{\"a}stina / 113 \\
+                 J{\"u}dische Gesundung / 114 \\
+                 Brief an einen Araber / 115 \\
+                 {\"U}ber die Notwendigkeit des Zionismus / 116 \\
+                 Aphorismen f{\"u}r Leo Baeck / 118 \\
+                 V: Wisssenschaftliche Beitr{\"a}ge / 119 \\
+                 Prinzipien der Forschung / 119 \\
+                 Prinzipien der theoretischen Physik / 122 \\
+                 Zur Methodik der theoretischen Physik / 126 \\
+                 Geometrie und Erfahrung / 132 \\
+                 Was ist Relativit{\"a}tstheorie? / 141 \\
+                 {\"U}ber Rela{\"u}vit{\"a}tstheorie / 146 \\
+                 {\"U}ber die Entstehung der Allgemeinen
+                 Relativit{\"a}tstheorie / 150 \\
+                 Das Raum-, {\"A}ther- und Feld-Problem der Physik / 154
+                 \\
+                 Johannes Kepler / 164 \\
+                 Newtons Mechanik / 169 \\
+                 Maxwells Einflu{\ss} / 177 \\
+                 Das Flettner-Schiff / 182 \\
+                 Die Ursache der M{\"a}anderbildung der
+                 Flu{\ss}l{\"a}ufe / 186 \\
+                 {\"U}ber wissenschaftliche Wahrheit / 191 \\
+                 Zur Erniedrigung des wissenschaftlichen Menschen / 191
+                 \\
+                 Anmerkungen des Herausgebers / 195",
+}
+
+@Article{Einstein:2005:PPS,
+  author =       "A. Einstein",
+  title =        "Physics, philosophy, and scientific progress",
+  journal =      j-PHYS-TODAY,
+  volume =       "58",
+  number =       "6",
+  pages =        "46--48",
+  month =        jun,
+  year =         "2005",
+  CODEN =        "PHTOAD",
+  DOI =          "http://dx.doi.org/10.1063/1.1996474",
+  ISSN =         "0031-9228",
+  ISSN-L =       "0031-9228",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Physics Today",
+  journal-URL =  "http://www.physicstoday.org/",
+}
+
+@Book{Einstein:2005:RSG,
+  author =       "Albert Einstein and Robert W. Lawson and Robert Geroch
+                 and David C. Cassidy",
+  title =        "{Relativity}: The {Special} and {General Theory}",
+  publisher =    "Pi Press",
+  address =      "New York, NY, USA",
+  edition =      "The masterpiece science",
+  pages =        "xxvi + 259",
+  year =         "2005",
+  ISBN =         "0-13-186261-8",
+  ISBN-13 =      "978-0-13-186261-6",
+  LCCN =         "QC173.55 .E384513 2005",
+  bibdate =      "Tue Oct 11 05:00:47 MDT 2005",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  note =         "Translated by Robert W. Lawson. Introduction by Roger
+                 Penrose. Commentary by Robert Geroch. Historical essay
+                 by David Cassidy.",
+  URL =          "http://catdir.loc.gov/catdir/enhancements/fy1204/2004117390-b.html;
+                 http://catdir.loc.gov/catdir/enhancements/fy1204/2004117390-d.html",
+  abstract =     "Robert Geroch builds on Einstein's work with
+                 commentary that addresses the ideas at the heart of the
+                 theory, bringing a modern understanding of relativity
+                 to the text. He elucidates how special relativity is a
+                 reconciliation of the contradictions between the nature
+                 of light and the principle of relativity; he expands on
+                 Einstein's treatment of the geometry of space--time and
+                 the fundamental notion of an ``event''; he explains in
+                 detail, but without technical language, the equivalence
+                 of inertial and gravitational mass, a cornerstone of
+                 general relativity.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Originally published: New York: H. Holt, 1920.",
+  subject =      "Relativity (physics)",
+  tableofcontents = "Special theory of relativity \\
+                 Physical meaning of geometrical proportions \\
+                 System of co-ordinates \\
+                 Space and time in classical mechanics \\
+                 Galilean system of co-ordinates \\
+                 Theorem of the addition of velocities employed in
+                 classical mechanics \\
+                 On the idea of time in physics \\
+                 Relativity of simultaneity \\
+                 Lorentz transformation \\
+                 General theory of relativity \\
+                 Considerations on the universe as a whole \\
+                 Appendixes. Simple derivation of the Lorentz
+                 transformation \\
+                 Minkowski's four-dimensional space (``World'') \\
+                 The experimental confirmation of the general theory of
+                 relativity",
+}
+
+@Article{Einstein:2005:TRS,
+  author =       "Albert Einstein",
+  title =        "Theoretical remark on the superconductivity of
+                 metals",
+  journal =      "arXiv.org",
+  day =          "27",
+  month =        oct,
+  year =         "2005",
+  bibdate =      "Tue Jun 05 17:06:25 2012",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translation of Albert Einstein's article
+                 ``Theoretische Bemerkungen zur Supraleitung der
+                 Metalle'' \cite{Einstein:1922:TBS}, Gedenkboek aangeb.
+                 aan H. Kamerlingh Onnes, eaz. Leiden, E. IJdo, 1922
+                 (page 435) Translated by Bjoern S. Schmekel with the
+                 courtesy of the Kamerlingh Onnes Laboratory, Leiden
+                 Institute of Physics, Leiden University. A typo in the
+                 citation of the original article has been corrected",
+  URL =          "http://arXiv.org/abs/physics/0510251",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Aiken:2006:HUC,
+  author =       "Conrad Aiken and Pearl S. Buck and Leo Connellan and
+                 Harry Crews and James Dickey and Albert Einstein and T.
+                 S. Eliot and Jesse Hill Ford and John Gardner and
+                 George Garrett and Richard Howard and Katherine Anne
+                 Porter and Lewis P. Simpson and Allen Tate and Lionel
+                 Trilling and Evelyn Waugh and E. B. White and Edmund
+                 Wilson and Stephen Corey",
+  title =        "``Into the hectic unknown'': Correspondence from the
+                 archives of {{The Georgia Review}},
+                 1947--76",
+  journal =      "Georgia Review",
+  volume =       "60",
+  number =       "3--4",
+  pages =        "606--698",
+  month =        "Fall \slash Winter",
+  year =         "2006",
+  ISSN =         "0016-8386",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:2006:ER,
+  author =       "Albert Einstein",
+  title =        "The {Einstein} reader",
+  publisher =    pub-CITADEL-PRESS,
+  address =      pub-CITADEL-PRESS:adr,
+  pages =        "ix + 257",
+  year =         "2006",
+  ISBN =         "0-8065-2791-9 (paperback)",
+  ISBN-13 =      "978-0-8065-2791-8 (paperback)",
+  LCCN =         "QC16.E5 A25 2006",
+  bibdate =      "Thu Jan 25 18:26:01 MST 2007",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 melvyl.cdlib.org:210/CDL90",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Einstein, Albert; Correspondence; Contributions in
+                 philosophy; Philosophy, German; 20th century",
+  subject-dates = "1879--1955; 1879--1955; 1879--1955.",
+}
+
+@Book{Einstein:2006:RSGa,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: The {Special} and the {General Theory}",
+  publisher =    pub-PENGUIN,
+  address =      pub-PENGUIN:adr,
+  pages =        "xxvii + 129",
+  year =         "2006",
+  ISBN =         "0-14-303982-2, 0-486-41714-X, 1-4406-2712-6 (e-book)",
+  ISBN-13 =      "978-0-14-303982-2, 978-1-4406-2712-5 (e-book)",
+  LCCN =         "QC173.55 .E384513 2006",
+  bibdate =      "Thu Jan 25 18:22:50 MST 2007",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  note =         "Translated by Robert W. Lawson.",
+  series =       "Penguin classics",
+  URL =          "http://www.loc.gov/catdir/toc/fy0703/2005058696.html",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Previously published (in English): New York: H. Holt,
+                 1920. Editor may be Nigel Calder. Also appears as Dover
+                 edition of 1920 original.",
+  subject =      "Relativity (Physics)",
+  tableofcontents = "Part I \\
+                 The Special Theory of Relativity \\
+                 1. Physical Meaning of Geometrical Propositions / 7 \\
+                 2. The System of Co-ordinates / 10 \\
+                 3. Space and Time in Classical Mechanics / 13 \\
+                 4. The Galileian System of Co-ordinates / 15 \\
+                 5. The Principle of Relativity (in the Restricted
+                 Sense) / 16 \\
+                 6. The Theorem of the Addition of Velocities \\
+                 Employed in Classical Mechanics / 19 \\
+                 7. The Apparent Incompatibility of the Law of \\
+                 Propagation of Light with the Principle of Relativity /
+                 20 \\
+                 8. On the Idea of Time in Physics / 23 \\
+                 9. The Relativity of Simultaneity / 26 \\
+                 10. On the Relativity of the Conception of Distance /
+                 29 \\
+                 11. The Lorentz Transformation / 31 \\
+                 12. The Behaviour of Measuring-Rods and Clocks \\
+                 in Motion / 36 \\
+                 13. Theorem of the Addition of the Velocities. \\
+                 The Experiment of Fizeau / 38 \\
+                 14. The Heuristic Value of the Theory of Relativity /
+                 42 \\
+                 15. General Results of the Theory / 44 \\
+                 16. Experience and the Special Theory of Relativity /
+                 48 \\
+                 17. Minkowski's Four-Dimensional Space / 52 \\
+                 Part II \\
+                 The General Theory of Relativity \\
+                 18. Special and General Principle of Relativity / 57
+                 \\
+                 19. The Gravitational Field / 60 \\
+                 20. The Equality of Inertial and Gravitational Mass as
+                 an \\
+                 Argument for the General Postulate of Relativity / 63
+                 \\
+                 21. In What Respects Are the Foundations of Classical
+                 \\
+                 Mechanics and of the Special Theory of Relativity \\
+                 Unsatisfactory? / 67 \\
+                 22. A Few Inferences from the General Principle of \\
+                 Relativity / 69 \\
+                 23. Behaviour of Clocks and Measuring-Rods on a \\
+                 Rotating Body of Reference / 73 \\
+                 24. Euclidean and Non-Euclidean Continuum / 76 \\
+                 25. Gaussian Co-ordinates / 79 \\
+                 26. The Space--time Continuum of the Special Theory \\
+                 of Relativity Considered as a Euclidean Continuum / 83
+                 \\
+                 27. The Space--time Continuum of the General Theory \\
+                 of Relativity Is Not a Euclidean Continuum / 85 \\
+                 28. Exact Formulation of the General Principle of \\
+                 Relativity / 88 \\
+                 29. The Solution of the Problem of Gravitation on the
+                 \\
+                 Basis of the General Principle of Relativity / 91 \\
+                 Part III \\
+                 Considerations on the Universe as a Whole \\
+                 30. Cosmological Difficulties of Newton's Theory / 97
+                 \\
+                 31. The Possibility of a ``Finite'' and Yet \\
+                 ``Unbounded'' Universe / 99 \\
+                 32. The Structure of Space According to the General \\
+                 Theory of Relativity / 103 \\
+                 Appendices \\
+                 1. Simple Derivation of the Lorentz Transformation /
+                 105 \\
+                 2. Minkowski's Four-Dimensional Space (``World'') / 111
+                 \\
+                 3. The Experimental Confirmation of the General \\
+                 Theory of Relativity / 113 \\
+                 (a) Motion of the Perihelion of Mercury / 114 \\
+                 (b) Deflection of Light by a Gravitational Field / 116
+                 \\
+                 (c) Displacement of Spectral Lines towards the Red /
+                 118",
+  xxnote =       "Introduction by Roger Penrose.",
+}
+
+@Book{Einstein:2006:RSGb,
+  author =       "Albert Einstein and Robert W. Lawson and Robert Geroch
+                 and David C. Cassidy",
+  title =        "{Relativity}: The {Special} and the {General Theory}",
+  publisher =    "Plume Book",
+  address =      "New York, NY, USA",
+  pages =        "xxvii + 129",
+  year =         "2006",
+  ISBN =         "0-452-28784-7",
+  ISBN-13 =      "978-0-452-28784-6",
+  LCCN =         "QC173.55 .E3613 2006",
+  bibdate =      "Thu Jan 25 18:22:50 MST 2007",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  note =         "Introduction by Roger Penrose.",
+  series =       "Penguin classics",
+  URL =          "http://www.loc.gov/catdir/toc/fy0703/2005058696.html",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Previously published (in English): New York: H. Holt,
+                 1920.",
+  subject =      "Relativity (Physics)",
+}
+
+@Book{Einstein:2006:WSI,
+  author =       "Albert Einstein",
+  title =        "The world as {I} see it",
+  publisher =    "Filiquarian Publishing",
+  address =      "Minneapolis, MN, USA",
+  pages =        "127",
+  year =         "2006",
+  ISBN =         "1-59986-824-5",
+  ISBN-13 =      "978-1-59986-824-0",
+  LCCN =         "QC71 .E5513 2006",
+  bibdate =      "Sat Sep 24 13:47:54 MDT 2011",
+  bibsource =    "aubrey.tamu.edu:7090/voyager;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Translation of: Mein Weltbild.",
+  subject =      "Einstein, Albert; Physics; Science; Philosophy; Social
+                 aspects; Religion and science; Jews; Peace",
+  subject-dates = "1879--1955",
+}
+
+@InCollection{Einstein:2007:SR,
+  author =       "Albert Einstein",
+  title =        "The scientist's responsibilities",
+  crossref =     "Whitfield:2007:WMR",
+  pages =        "??--??",
+  year =         "2007",
+  bibdate =      "Thu Sep 15 14:12:51 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:2007:STR,
+  author =       "Albert Einstein",
+  title =        "The special theory of relativity",
+  crossref =     "Whitfield:2007:WMR",
+  pages =        "??--??",
+  year =         "2007",
+  bibdate =      "Thu Sep 15 14:12:51 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:2007:TR,
+  author =       "Albert Einstein",
+  title =        "The theory of relativity",
+  crossref =     "Whitfield:2007:WMR",
+  pages =        "??--??",
+  year =         "2007",
+  bibdate =      "Thu Sep 15 14:12:51 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:2007:W,
+  author =       "Albert Einstein",
+  title =        "The way out",
+  crossref =     "Masters:2007:OWN",
+  pages =        "??--??",
+  year =         "2007",
+  bibdate =      "Thu Sep 15 14:12:51 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@InCollection{Einstein:2007:X,
+  author =       "Albert Einstein",
+  title =        "{$ E = m c^2 $}",
+  crossref =     "Whitfield:2007:WMR",
+  pages =        "??--??",
+  year =         "2007",
+  bibdate =      "Thu Sep 15 14:12:51 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Booklet{Einstein:2008:CBI,
+  author =       "Albert Einstein and Anne J. Kox and Tilman Sauer and
+                 Diana Kormos Buchwald and Rudy Hirschmann and Osik
+                 Moses and Benjamin Aronin and Jennifer Stolper",
+  title =        "Cumulative Bibliography and Index of Citations to
+                 Volumes 1--10: Collected Papers of {Albert Einstein}",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  pages =        "158",
+  day =          "5",
+  month =        dec,
+  year =         "2008",
+  bibdate =      "Sat Jul 02 11:43:03 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  URL =          "http://press.princeton.edu/books/einstein11/c_biblio.pdf",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:2008:NST,
+  author =       "Albert Einstein",
+  title =        "The Necessity of Students \& Teachers as Science
+                 Researchers",
+  journal =      j-AM-BIOL-TEACH,
+  volume =       "70",
+  number =       "9",
+  pages =        "518--519",
+  month =        nov # "\slash " # dec,
+  year =         "2008",
+  DOI =          "http://dx.doi.org/10.2307/27669333",
+  ISSN =         "0002-7685 (print), 0002-8444 (electronic), 1938-4211,
+                 1938-422X",
+  ISSN-L =       "0002-7685",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "The American Biology Teacher",
+  journal-URL =  "http://abt.ucpress.edu/content/by/year",
+}
+
+@Article{Einstein:2008:UOL,
+  author =       "Albert Einstein",
+  title =        "Unpublished opening lecture for the course on the
+                 {Theory of Relativity} in {Argentina}, 1925
+                 (Reprinted)",
+  journal =      j-SCI-CONTEXT,
+  volume =       "21",
+  number =       "3",
+  pages =        "451--459",
+  month =        sep,
+  year =         "2008",
+  CODEN =        "SCCOEW",
+  DOI =          "http://dx.doi.org/10.1017/S0269889708001865",
+  ISSN =         "0269-8897 (print), 1474-0664 (electronic)",
+  ISSN-L =       "0269-8897",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 http://www.math.utah.edu/pub/tex/bib/scicontext.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Science in Context",
+}
+
+@Book{Einstein:2009:CJV,
+  author =       "Albert Einstein",
+  title =        "Comment je vois le monde. ({French}) [{How} {I} see
+                 the world]",
+  volume =       "183",
+  publisher =    "Flammarion",
+  address =      "Paris, France",
+  pages =        "245",
+  year =         "2009",
+  ISBN =         "2-08-122904-8 (paperback)",
+  ISBN-13 =      "978-2-08-122904-4 (paperback)",
+  LCCN =         "QC16E5 A514.2009",
+  bibdate =      "Fri Aug 21 11:07:14 MDT 2015",
+  bibsource =    "fsz3950.oclc.org:210/WorldCat;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  series =       "Champs. Sciences",
+  acknowledgement = ack-nhfb,
+  author-dates = "(1879--1955)",
+  language =     "French",
+  remark =       "French translation of Mein Weltbild.",
+  subject =      "Einstein, Albert; Sciences; Aspect moral.; Vie
+                 (philosophie).; Weltanschauung.; Philosophie.;
+                 Physique; Relativit{\'e} (physique).; Pacifisme.;
+                 Philosophie.; Th{\'e}orie politique.; Th{\'e}orie
+                 scientifique.; Philosophie",
+  subject-dates = "1879--1955",
+}
+
+@Book{Einstein:2009:CPAc,
+  author =       "Albert Einstein and Diana {Kormos Buchwald} and Ze'ev
+                 Rosenkranz and Tilman Sauer and J{\'o}zsef Illy and
+                 Virginia Iris Holmes",
+  title =        "The Collected Papers of {Albert Einstein}, Volume 12:
+                 The {Berlin} Years: Correspondence, {January--December
+                 1921} ({English} translation supplement)",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  year =         "2009",
+  ISBN =         "0-691-14190-8",
+  ISBN-13 =      "978-0-691-14190-9",
+  LCCN =         "????",
+  bibdate =      "Tue Oct 19 21:53:49 2010",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "Translated by Ann M. Hentschel; Klaus Hentschel,
+                 consultant.",
+  URL =          "http://press.princeton.edu/titles/8954.html",
+  acknowledgement = ack-nhfb,
+}
+
+@Book{Einstein:2009:EES,
+  author =       "Albert Einstein",
+  title =        "{Einstein}'s essays in science",
+  publisher =    pub-DOVER,
+  address =      pub-DOVER:adr,
+  pages =        "xi + 114",
+  year =         "2009",
+  ISBN =         "0-486-47011-3",
+  ISBN-13 =      "978-0-486-47011-5",
+  LCCN =         "QC71 .E513 2009",
+  bibdate =      "Sat Sep 24 13:29:43 MDT 2011",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  URL =          "http://store.doverpublications.com/0486470113.html;
+                 http://www.loc.gov/catdir/enhancements/fy0909/2009000860-d.htm",
+  abstract =     "These accessible speeches and essays by the renowned
+                 scientist profile influential physicists and explore
+                 the areas of physics to which Einstein made major
+                 contributions. Subjects include theoretical physics,
+                 relativity, and the principles of research and
+                 scientific truth as well as personalities such as
+                 Kepler, Newton, Maxwell, Bohr, and Planck.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Translated from the German by Alan Harris. Originally
+                 published: New York: Wisdom Library, 1934.",
+  subject =      "Physics; Science; Philosophy; Peace; Social aspects",
+}
+
+@Book{Einstein:2009:RET,
+  author =       "Albert Einstein",
+  title =        "Relativity: {Einstein}'s theory of spacetime, time
+                 dilation, gravity, and cosmology",
+  publisher =    "Red and Black Publishers",
+  address =      "St. Petersburg, FL, USA",
+  pages =        "151",
+  year =         "2009",
+  ISBN =         "1-934941-46-8",
+  ISBN-13 =      "978-1-934941-46-1",
+  LCCN =         "QC173.6 .E3613 2009",
+  bibdate =      "Tue May 5 07:56:21 MDT 2015",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "Translated from the German by Robert W. Lawson.",
+  subject =      "General relativity (Physics)",
+}
+
+@Article{Einstein:2009:WS,
+  author =       "Albert Einstein",
+  title =        "Why Socialism?",
+  journal =      "Monthly Review --- an Independent Socialist Magazine",
+  volume =       "61",
+  number =       "1",
+  pages =        "55--61",
+  month =        may,
+  year =         "2009",
+  ISSN =         "0027-0520",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Shikibu:2009:L,
+  author =       "Murasaki Shikibu and Jack McLaughlin and Richard White
+                 and Marge Piercy and Jacob Riis and John Berryman and
+                 Ronald Blythe and Susan B. Anthony and Henry Mayhew and
+                 Albert Einstein and Henry David Thoreau",
+  title =        "Labor",
+  journal =      "American Scholar",
+  volume =       "78",
+  number =       "4",
+  pages =        "118--119",
+  month =        "Fall",
+  year =         "2009",
+  ISSN =         "0003-0937",
+  bibdate =      "Tue Jun 11 08:06:29 MDT 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+}
+
+@Article{Einstein:2010:CSQ,
+  author =       "Albert Einstein",
+  title =        "Comment: a skeptic of quantum theory explains his
+                 misgivings",
+  journal =      j-SCIENCE-NEWS,
+  volume =       "178",
+  number =       "11",
+  pages =        "36--36",
+  year =         "2010",
+  CODEN =        "SCNEBK",
+  DOI =          "http://dx.doi.org/10.1002/scin.5591781125",
+  ISSN =         "0036-8423 (print), 1943-0930 (electronic)",
+  ISSN-L =       "0036-8423",
+  bibdate =      "Sat Feb 9 08:41:56 2013",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Science News (Washington, DC)",
+}
+
+@InCollection{Einstein:2011:GGF,
+  author =       "Albert Einstein",
+  title =        "{Geleitwort}. ({German}) [Foreword]",
+  crossref =     "Diels:2011:LNG",
+  pages =        "??--??",
+  year =         "2011",
+  bibdate =      "Wed Oct 22 14:28:12 2014",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  acknowledgement = ack-nhfb,
+  language =     "German",
+}
+
+@Book{Einstein:2013:RSG,
+  author =       "Albert Einstein",
+  title =        "{Relativity}: the Special and the General Theory",
+  publisher =    pub-ROUTLEDGE,
+  address =      pub-ROUTLEDGE:adr,
+  pages =        "xvii + 166",
+  year =         "2013",
+  ISBN =         "0-415-85471-7 (paperback), 1-315-88674-X (e-book)",
+  ISBN-13 =      "978-0-415-85471-9 (paperback), 978-1-315-88674-9
+                 (e-book)",
+  LCCN =         "QC173.55 .E384513 2013",
+  bibdate =      "Thu Aug 20 08:41:04 MDT 2015",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  note =         "Translation from German by Robert W. (Robert William)
+                 Lawson and Derek J. Raine.",
+  series =       "Routledge great minds",
+  abstract =     "Time magazine's ``Man of the Century'', Albert
+                 Einstein is the founder of modern physics and his
+                 theory of relativity is the most important scientific
+                 idea of the modern era. In this short book, Einstein
+                 explains, using the minimum of mathematical terms, the
+                 basic ideas and principles of the theory that has
+                 shaped the world we live in today. Unsurpassed by any
+                 subsequent books on relativity, this remains the most
+                 popular and useful exposition of Einstein's immense
+                 contribution to human knowledge. With a new foreword by
+                 Derek Raine.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  remark =       "``First published in 1916; English edition first
+                 published in the United Kingdom 1920 by Methuen and Co.
+                 Ltd; First published by Routledge 1993.''.",
+  subject =      "Relativity (Physics)",
+  tableofcontents = "Cover \\
+                 Relativity \\
+                 Title Page \\
+                 Copyright Page \\
+                 Table of Contents \\
+                 Foreword to the Routledge Great Minds Edition \\
+                 Preface \\
+                 Part I The Special Theory of Relativity \\
+                 1 Physical Meaning of Geometrical Propositions \\
+                 2 The System of Co-ordinates \\
+                 3 Space and Time in Classical Mechanics \\
+                 4 The Galileian System of Co-ordinates \\
+                 5 The Principle of Relativity (in the Restricted Sense)
+                 \\
+                 6 The Theorem of the Addition of Velocities Employed in
+                 Classical Mechanics \\
+                 7 The Apparent Incompatibility of the Law of
+                 Propagation of Light with the Principle of Relativity
+                 \\
+                 8 On the Idea of Time in Physics9 The Relativity of
+                 Simultaneity10 On the Relativity of the Conception of
+                 Distance \\
+                 11 The Lorentz Transformation \\
+                 12 The Behaviour of Measuring-Rods and Clocks in Motion
+                 \\
+                 13 Theorem of the Addition of Velocities. The
+                 Experiment of Fizeau \\
+                 14 The Heuristic Value of the Theory of Relativity \\
+                 15 General Results of the Theory \\
+                 16 Experience and the Special Theory of Relativity \\
+                 17 Minkowski's Four-dimensional Space \\
+                 Part II The General Theory of Relativity \\
+                 18 Special and General Principle of Relativity \\
+                 19 The Gravitational Field20 The Equality of Inertial
+                 and Gravitational Mass as an Argument for the General
+                 Postulate of Relativity21 In what Respects are the
+                 Foundations of Classical Mechanics and of the Special
+                 Theory of Relativity Unsatisfactory? \\
+                 22 A Few Inferences from the General Principle of
+                 Relativity \\
+                 23 Behaviour of Clocks and Measuring-Rods on a Rotating
+                 Body of Reference \\
+                 24 Euclidean and non-Euclidean Continuum \\
+                 25 Gaussian Co-ordinates \\
+                 26 The Space--time Continuum of the Special Theory of
+                 Relativity Considered as a Euclidean Continuum27 The
+                 Space--time Continuum of the General Theory of
+                 Relativity is not a Euclidean Continuum28 Exact
+                 Formulation of the General Principle of Relativity \\
+                 29 The Solution of the Problem of Gravitation on the
+                 Basis of the General Principle of Relativity \\
+                 Part III Considerations on the Universe as a Whole \\
+                 30 Cosmological Difficulties of Newton's Theory \\
+                 31 The Possibility of a ``Finite'' and yet
+                 ``Unbounded'' Universe \\
+                 32 The Structure of Space according to the General
+                 Theory of Relativity \\
+                 Appendices \\
+                 1 Simple Derivation of the Lorentz Transformation
+                 [Supplementary to Section 11]2 Minkowski's
+                 Four-dimensional Space (``World'') [Supplementary to
+                 Section 17]3 The Experimental Confirmation of the
+                 General Theory of Relativity \\
+                 (a) Motion of the Perihelion of Mercury \\
+                 (b) Deflection of Light by a Gravitational Field \\
+                 (c) Displacement of Spectral Lines towards the Red \\
+                 4 The Structure of Space according to the General
+                 Theory of Relativity [Supplementary to Section 32] \\
+                 5 Relativity and the Problem of Space \\
+                 Bibliography \\
+                 Index",
+}
+
+@Book{Einstein:2015:CJV,
+  author =       "Albert Einstein",
+  title =        "Comment je vois le monde. ({French}) [{How} {I} see
+                 the world]",
+  publisher =    "????",
+  address =      "????",
+  pages =        "147",
+  year =         "2015",
+  ISBN =         "????",
+  ISBN-13 =      "????",
+  LCCN =         "????",
+  bibdate =      "Fri Aug 21 08:57:13 2015",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib",
+  note =         "French translation by Faroq Al-Hamid of
+                 Mein Weltbild.",
+  acknowledgement = ack-nhfb,
+  language =     "French",
+}
+
+@Article{Blum:2015:RGR,
+  author =       "Alexander Blum and Roberto Lalli and J{\"u}rgen Renn",
+  title =        "The Reinvention of General Relativity: A
+                 Historiographical Framework for Assessing One Hundred
+                 Years of Curved Space--time",
+  journal =      j-ISIS,
+  volume =       "106",
+  number =       "3",
+  pages =        "598--620",
+  month =        "",
+  year =         "2015",
+  CODEN =        "ISISA4",
+  DOI =          "http://dx.doi.org/10.1086/683425",
+  ISSN =         "0021-1753 (print), 1545-6994 (electronic)",
+  ISSN-L =       "0021-1753",
+  bibdate =      "Thu Nov 12 18:41:59 MST 2015",
+  bibsource =    "http://www.jstor.org/action/showPublication?journalCode=isis;
+                 http://www.jstor.org/stable/10.1086/681973;
+                 http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 http://www.math.utah.edu/pub/tex/bib/isis2010.bib",
+  URL =          "http://www.jstor.org/stable/10.1086/683425",
+  acknowledgement = ack-nhfb,
+  fjournal =     "Isis",
+  journal-URL =  "http://www.jstor.org/page/journal/isis/about.html",
+}
+
+@Book{Einstein:2015:RSG,
+  author =       "Albert Einstein",
+  title =        "Relativity: the Special and the General theory",
+  publisher =    pub-PRINCETON,
+  address =      pub-PRINCETON:adr,
+  edition =      "100th anniversary",
+  pages =        "xviii + 300",
+  year =         "2015",
+  ISBN =         "0-691-16633-1 (hardcover)",
+  ISBN-13 =      "978-0-691-16633-9 (hardcover)",
+  LCCN =         "QC173.55 .E3843 2015",
+  bibdate =      "Thu Aug 20 08:41:02 MDT 2015",
+  bibsource =    "http://www.math.utah.edu/pub/tex/bib/einstein.bib;
+                 z3950.loc.gov:7090/Voyager",
+  note =         "With commentaries and background material by Hanoch
+                 Gutfreund and J{\"u}rgen Renn.",
+  acknowledgement = ack-nhfb,
+  author-dates = "1879--1955",
+  subject =      "Special relativity (Physics); General relativity
+                 (Physics); General relativity (Physics); Special
+                 relativity (Physics)",
+  tableofcontents = "Introduction \\
+                 Einstein as a missionary of science \\
+                 Einstein's booklet: Relativity: The special and the
+                 general theory \\
+                 Part I. The special theory of relativity \\
+                 Part II. The general theory of relativity \\
+                 Part III. Considerations on the universe as a whole \\
+                 Appendixes \\
+                 A reading companion: thirteen commentaries \\
+                 A history and survey of foreign-language editions \\
+                 Appended documents",
+}

--- a/publications.md
+++ b/publications.md
@@ -4,7 +4,6 @@ layout: page
 permalink: /publications/index.html
 ---
 <style>
-img { width: 80%; margin: 0 auto; display: block; }
 #bibbase .nav {
     position: inherit;
 }

--- a/publications.md
+++ b/publications.md
@@ -1,0 +1,22 @@
+---
+title: Publications
+layout: page
+permalink: /publications/index.html
+---
+<style>
+img { width: 80%; margin: 0 auto; display: block; }
+#bibbase .nav {
+    position: inherit;
+}
+#bibbase img.bibbase_icon {
+    display: inherit;
+}
+#bibbase .author {
+    padding: 0;
+    margin: 0;
+}
+</style>
+
+<center><h1>{{ page.title }}</h1></center>
+
+<script src="https://bibbase.org/show?bib={{ site.url }}/{{ site.citations_bib }}&jsonp=1"></script>


### PR DESCRIPTION
Uses services provided by https://bibbase.org to generate a dynamic,
embeddable widget.

Page can be enabled by setting `publications` to `true` in _config.yml
and adding `citations.bib` file (in bibtex format) to the repo assets directory.

A working example page: http://www.vivekkrish.com/publications/