### PR TITLE
Fix social link issue (#232) on mobile versions

### DIFF
--- a/_sass/components/social-links.sass
+++ b/_sass/components/social-links.sass
@@ -15,12 +15,13 @@
 
         &:hover:before
             opacity: 1
+            display: inline-block
             transform: translate3d(0,0,0)
             white-space: nowrap
 
         &:before
             content: attr(data-title)
-            display: inline-block
+            display: none
             position: absolute
             bottom: -34px
             left: -6px


### PR DESCRIPTION
Now the social links popups are created only when mouse is over the link.
