### PR TITLE
Author's tweeter is now author specific

### DIFF
--- a/_includes/author.html
+++ b/_includes/author.html
@@ -10,7 +10,7 @@
         <div class="share">
             <!-- Note: Only use three share links if your site width is set to large -->
             <!-- If site width is set to normal, you may choose any two share links -->
-            <a class="twitter" href="https://twitter.com/intent/tweet?text={{ site.url }}{{ page.url }} - {{ page.title }} by @{{ site.twitter }}">
+            <a class="twitter" href="https://twitter.com/intent/tweet?text={{ site.url }}{{ page.url }} - {{ page.title }} by @{{ site.authors[page.author].twitter }}">
                 <svg class="icon icon-twitter"><use xlink:href="#icon-twitter"></use></svg><span class="icon-twitter">Tweet</span>
             </a>
 


### PR DESCRIPTION
Hi,
And thanks for this great theme!

I changed the  twitter account used in the `author` section of a post to the actual [post author's tweeter](https://github.com/sergiokopplin/indigo/blob/gh-pages/_config.yml#L61). It is  currently the global site's twitter. 

Nicolas