### PR TITLE
Refactor social-links.html to use information encoded in _data/social-links.yml

### DIFF
--- a/_data/social-links.yml
+++ b/_data/social-links.yml
@@ -1,15 +1,14 @@
-# yaml manifest of supported social links
-#
-# requirements:
+# Yaml manifest of supported social links
+# Requirements:
 # `name`
-#     - plain-text name of the site (e.g. facebook)
+#     - plain-text name of the site (e.g. twitter)
 #     - **mandatory**
-# `url-prefix`
-#     - part of the site URL prior to username (e.g. facebook.com/)
-#     - must include the trailing slash
+# `url-pattern`
+#     - site URL pattern containing a placeholder string (e.g. twitter.com/__USERNAME__)
+#     - placeholder will be replaced by username or value specified in _config.yml (e.g. twitter.com/mytwitter)
 #     - **mandatory** (for non-email type links)
 # `url-scheme`
-#     - corresponds to the hardcoded URI/URN url-scheme (e.g. https://)
+#     - the hardcoded URI/URN url_scheme (e.g. https://)
 #     - can be one of: ['https://', 'http://', 'mailto:']
 #     - defaults to '//'
 #     - **optional**
@@ -19,86 +18,87 @@
 #     - **optional**
 #
 - name: facebook
-  url-prefix: facebook.com/
+  url-pattern: facebook.com/__USERNAME__
 
 - name: twitter
-  url-prefix: twitter.com/
+  url-pattern: twitter.com/__USERNAME__
 
 - name: google
-  url-prefix: plus.google.com/
+  url-pattern: plus.google.com/+__USERNAME__
 
 - name: instagram
-  url-prefix: instagram.com/
+  url-pattern: instagram.com/__USERNAME__
 
 - name: pinterest
-  url-prefix: pinterest.com/
+  url-pattern: pinterest.com/__USERNAME__
 
 - name: linkedin
-  url-prefix: linkedin.com/in/
+  url-pattern: linkedin.com/in/__USERNAME__
 
 - name: youtube
-  url-prefix: youtube.com/
+  url-pattern: youtube.com/__USERNAME__
 
 - name: spotify
-  url-prefix: open.spotify.com/user/
+  url-pattern: open.spotify.com/user/__USERNAME__
 
 - name: lastfm
-  url-prefix: last.fm/user/
+  url-pattern: last.fm/user/__USERNAME__
 
 - name: github
-  url-prefix: github.com/
+  url-pattern: github.com/__USERNAME__
 
 - name: gitlab
-  url-prefix: gitlab.com/
+  url-pattern: gitlab.com/__USERNAME__
 
 - name: keybase
-  url-prefix: keybase.io/
+  url-pattern: keybase.io/__USERNAME__
   icon: key
 
 - name: stackoverflow
-  url-prefix: stackoverflow.com/users/
+  url-pattern: stackoverflow.com/users/__USERNAME__
 
 - name: quora
-  url-prefix: www.quora.com/profile/
+  url-pattern: www.quora.com/profile/__USERNAME__
 
 - name: reddit
-  url-prefix: reddit.com/user/
+  url-pattern: reddit.com/user/__USERNAME__
 
 - name: medium
-  url-prefix: medium.com/@
+  url-pattern: medium.com/@__USERNAME__
 
 - name: lanyrd
-  url-prefix: lanyrd.com/
+  url-pattern: lanyrd.com/__USERNAME__
   url-scheme: 'http://'
   icon: microphone
 
 - name: scholar
-  url-prefix: scholar.google.com/citations?user=
+  url-pattern: scholar.google.com/citations?user=__USERNAME__
 
 - name: researchgate
-  url-prefix: www.researchgate.net/profile/
+  url-pattern: www.researchgate.net/profile/__USERNAME__
 
 - name: mendeley
-  url-prefix: mendeley.com/profiles/
+  url-pattern: mendeley.com/profiles/__USERNAME__
 
 - name: pubmed
-  url-prefix: www.ncbi.nlm.nih.gov/myncbi/browse/collection/
+  url-pattern: www.ncbi.nlm.nih.gov/myncbi/browse/collection/__USERNAME__
 
 - name: orcid
-  url-prefix: orcid.org/
+  url-pattern: orcid.org/__USERNAME__
 
 - name: impactstory
-  url-prefix: profiles.impactstory.org/u/
+  url-pattern: profiles.impactstory.org/u/__USERNAME__
 
 - name: figshare
-  url-prefix: fighshare.com/authors/
+  url-pattern: fighshare.com/authors/__USERNAME__
 
 - name: slideshare
-  url-prefix: www.slideshare.net/
+  url-pattern: www.slideshare.net/__USERNAME__
 
 - name: speakerdeck
-  url-prefix: speakerdeck.com/
+  url-pattern: speakerdeck.com/__USERNAME__
 
 - name: email
+  url-pattern: '__USERNAME__'
   url-scheme: 'mailto:'
   icon: mail

--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -1,5 +1,5 @@
 <div class="social-links">
-{% assign links = '' | split: '' %}
+{% assign links = null | compact %}
 {% if site.social-links-order %}
     {% for link in site.social-links-order %}
         {% assign link-elem = include.links | where: "name", link %}
@@ -10,10 +10,12 @@
 {% endif %}
 
 {% for link in links %}
-    {% assign link-username = site[link.name] %}
-    {% if link-username %}
-    <a target="_blank" class="link" data-title="{{ link.url-prefix }}{{ link-username }}" href="{{ link.url-scheme | default: '//' }}{{ link.url-prefix }}{{ link-username }}">
-        <svg class="icon icon-{{ link.icon | default: link.name }}"><use xlink:href="#icon-{{ link.icon | default: link.name }}"></use></svg>
+    {% assign username = site[link.name] %}
+    {% if username %}
+    {% assign icon-name = link.icon | default: link.name %}
+    {% assign site-url = link.url-pattern | replace: '__USERNAME__', username %}
+    <a target="_blank" class="link" data-title="{{ site-url }}" href="{{ link.url-scheme | default: '//' }}{{ site-url }}">
+        <svg class="icon icon-{{ icon-name }}"><use xlink:href="#icon-{{ icon-name }}"></use></svg>
     </a>
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
This PR refactors the social links element of the page, by using data encoded in the `_data/social-links.yml` file to construct the link outs.

This PR also adds the following:
+ Add placeholder links to several scientific sites (like Google Scholar, PubMed, etc.)
+ Add supporting SVG icons for scientific sites

Documentation: https://vivekkrish.com/indigo/adding-configuring-social-links/