### PR TITLE
Changed 'gems' configuration option to 'plugins'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -100,7 +100,7 @@ show-author: true
 # do you want some animations?
 animation: true
 
-gems:
+plugins:
   - jekyll-seo-tag
   - jekyll-gist
   - jekyll-feed


### PR DESCRIPTION
Fix to avoid warning: "Deprecation: The 'gems' configuration option has been renamed to 'plugins'. Please update your config file accordingly."