### PR TITLE
Only include google analytics script if a token is set.

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -44,7 +44,9 @@ layout: compress
 
     {% include icons.html %}
 
-    {% include analytics-google.html %}
+    {% if site.analytics-google %}
+        {% include analytics-google.html %}
+    {% endif %}
 
 </body>
 </html>


### PR DESCRIPTION
I noticed that even though I had commented out `analytics-google: ...` in my `_config.yml` file, the website was loading a google analytics script. So I've added a check in `default.html` to only include `analytics-google.html` if a token is set by the user.