### PR TITLE
Change Google Analytics code position

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -5,6 +5,10 @@ layout: compress
 <html lang="en">
 <head>
 
+    {% if site.analytics-google %}
+        {% include analytics-google.html %}
+    {% endif %}
+
     <meta charset="utf-8">
     <meta http-equiv=X-UA-Compatible content="IE=edge,chrome=1">
     <meta name=viewport content="width=device-width, initial-scale=1">
@@ -43,10 +47,6 @@ layout: compress
     </div>
 
     {% include icons.html %}
-
-    {% if site.analytics-google %}
-        {% include analytics-google.html %}
-    {% endif %}
 
 </body>
 </html>


### PR DESCRIPTION
According to [Google Analytics](https://support.google.com/analytics/answer/1008080), the tracking code snippet is recommended to be put right after the \<head\> tag.