### PR TITLE
Updated rvm version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.2.2
+ - 2.2.5
 
 before_script:
  - chmod +x travis.sh


### PR DESCRIPTION
The rvm version 2.2.2 breaks the builds on GitHub. Updated to 2.2.5.