### PR TITLE
fix: remove jemoji example

### DIFF
--- a/_posts/2015-02-24-markdown-extra-components.markdown
+++ b/_posts/2015-02-24-markdown-extra-components.markdown
@@ -11,7 +11,6 @@ tag:
 category: blog
 author: jamesfoster
 description: Markdown summary with different options
-# jemoji: '<img class="emoji" title=":ramen:" alt=":ramen:" src="https://assets.github.com/images/icons/emoji/unicode/1f35c.png" height="20" width="20" align="absmiddle">'
 ---
 
 ## Summary:


### PR DESCRIPTION
As seen on #72 , jemoji can now be generated directly with their name.