### PR TITLE
Fix og:image when site.picture is external

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@ layout: compress
 
     <meta name=description content="{{ site.bio }}">
     <meta name=author content="{{ site.name }}">
-    <meta property="og:image" content="{{ site.url }}/{{ site.picture }}">
+    <meta property="og:image" content="{% if site.external-image %}{{ site.picture }}{% else %}{{ site.url }}/{{ site.picture }}{% endif %}">
     <meta property="og:type" content="profile">
 
     {% seo %}


### PR DESCRIPTION
Fixes a case where if `external-image: true`, the below `<meta property="og:image">` tag contains an incorrect image URL.

This appears to be the only missed case; all other cases have the conditional `{% if site.external-image %}`.

Before:

```html
<meta property="og:image" content="https://user.github.io/https://imgur.com/external.png">
```

After:

```html
<meta property="og:image" content="https://imgur.com/external.png">
```