### PR TITLE
bugfix unrecongnized Liquid tag 'fa_svg'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -122,6 +122,8 @@ plugins:
   - jemoji
   - jekyll-admin
   - jekyll-paginate-v2
+  - jekyll-fontawesome-svg
+
 
 jekyll-mentions:
     base_url: https://github.com


### PR DESCRIPTION
I got the following error message when setting up my Github page. (same as #416 #418)

> The tag `fa_svg` on line 14 in `_includes/author.html` is not a recognized Liquid tag

I solved it by updating `plugins` in `_config.yml`.