### PR TITLE
Use 'post' class even if there are no tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,7 +29,7 @@ layout: compress
 <body>
 
     <div class="wrapper-{% if site.width == "normal" %}normal{% elsif site.width == "large" %}large{% endif %}">
-        {% if page.tag %}
+        {% if page.layout == "post" %}
             <div class="post">
         {% else %}
             {% if showHeader != true %}


### PR DESCRIPTION
If I write a new post, but don't include `tag` in the front matter, it will take the look of the `page` class, even if there is a `layout: post` in the front matter. This PR fixes it.