### PR TITLE
fix(socials): change linkedin's href value

### DIFF
--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -30,7 +30,7 @@
     {% endif %}
 
     {% if site.linkedin %}
-        <a class="link" data-title="linkedin.com/in/{{ site.linkedin }}" href="https://linkedin.com/in/{{ site.linkedin }}" target="_blank">
+        <a class="link" data-title="linkedin.com/in/{{ site.linkedin }}" href="https://www.linkedin.com/in/{{ site.linkedin }}" target="_blank">
             <svg class="icon icon-linkedin"><use xlink:href="#icon-linkedin"></use></svg>
         </a>
     {% endif %}


### PR DESCRIPTION
If you try to use linkedin without www in front of it, it throws `Hmm. We’re having trouble finding that site.` on Firefox. 