### PR TITLE
social-links: add support for GitLab instances other than gitlab.com

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -42,7 +42,8 @@ twitter: mytwitter
 # youtube: myyoutube
 # spotify: myspotify
 github: mygithub
-# gitlab: mygitlab
+# gitlab-user: mygitlab
+# gitlab-instance: gitlab.mydomain.com # defaults to gitlab.com
 # lastfm: mylastfm
 # stackoverflow: 7044681/mystackoverflow
 # quora: userquora

--- a/_includes/social-links.html
+++ b/_includes/social-links.html
@@ -59,8 +59,14 @@
         </a>
     {% endif %}
 
-    {% if site.gitlab %}
-        <a class="link" data-title="gitlab.com/{{ site.gitlab }}" href="https://gitlab.com/{{ site.gitlab }}" target="_blank">
+    {% if site.gitlab-instance %}
+      {% assign gitlab-instance = site.gitlab-instance %}
+    {% else %}
+      {% assign gitlab-instance = "gitlab.com" %}
+    {% endif %}
+
+    {% if site.gitlab-user %}
+        <a class="link" data-title="{{ gitlab-instance }}/{{ site.gitlab-user }}" href="https://{{ gitlab-instance }}/{{ site.gitlab-user }}" target="_blank">
             <svg class="icon icon-gitlab"><use xlink:href="#icon-gitlab"></use></svg>
         </a>
     {% endif %}


### PR DESCRIPTION
This allows configuring other GitLab instances (for example https://framagit.org )