### PR TITLE
Improve inline code CSS formatting

### DIFF
--- a/_sass/base/general.sass
+++ b/_sass/base/general.sass
@@ -90,7 +90,15 @@ figure.highlight
 	width: 100%
 	margin: 0
 
-code,
+code
+	padding: 2px 3px
+	font-family: $fontMonospace
+	font-size: 12px
+	vertical-align: middle
+	background: #eee
+	border-radius: 2px
+
+pre > code,
 tt
 	padding: 1px 0
 	font-family: $fontMonospace


### PR DESCRIPTION
I added a grey box and centered (vertical-align: middle) the inline code. This inline formatting is similar to the GitHub line formatting. I left the multiline CSS intact.