### PR TITLE
Removing unused namespace + deprecated "version" 

### DIFF
--- a/_includes/icons.html
+++ b/_includes/icons.html
@@ -1,9 +1,6 @@
 <svg
     display="none"
-    version="1.1"
-    xmlns="http://www.w3.org/2000/svg"
-    xmlns:xlink="http://www.w3.org/1999/xlink"
->
+    xmlns="http://www.w3.org/2000/svg">
     <defs>
         <symbol id="icon-rss" viewBox="0 0 1024 1024">
             <title>rss</title>


### PR DESCRIPTION
Removed unused namespace + absolute "version" according to: https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/version

> Deprecated: This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible; see the compatibility table at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.